### PR TITLE
fix codeowners template to automatically request PR review from phoenix-devs team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-@metal-toolbox/hollow-core
-@metal-toolbox/phoenix-devs
+* @metal-toolbox/phoenix-devs


### PR DESCRIPTION
originally had hollow-core team on here too, but figure we should just keep codeowners on this project a little tighter to lessen notifications for others.