### PR TITLE
Add internal-facing endpoints for deleting metadata or userdata

### DIFF
--- a/pkg/api/v1/router.go
+++ b/pkg/api/v1/router.go
@@ -71,6 +71,8 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 
 	rg.GET(InternalMetadataWithIDURI, authMw.AuthRequired(), authMw.RequiredScopes(readScopes("metadata")), r.instanceMetadataGetInternal)
 	rg.GET(InternalUserdataWithIDURI, authMw.AuthRequired(), authMw.RequiredScopes(readScopes("metadata")), r.instanceUserdataGetInternal)
+	rg.DELETE(InternalMetadataWithIDURI, authMw.AuthRequired(), authMw.RequiredScopes(deleteScopes("metadata")), r.instanceMetadataDelete)
+	rg.DELETE(InternalUserdataWithIDURI, authMw.AuthRequired(), authMw.RequiredScopes(deleteScopes("metadata")), r.instanceUserdataDelete)
 }
 
 // GetMetadataPath returns the path used by an instance to fetch Metadata
@@ -126,6 +128,15 @@ func readScopes(items ...string) []string {
 	s := []string{"read"}
 	for _, i := range items {
 		s = append(s, fmt.Sprintf("%s:read:%s", scopePrefix, i))
+	}
+
+	return s
+}
+
+func deleteScopes(items ...string) []string {
+	s := []string{"write", "delete"}
+	for _, i := range items {
+		s = append(s, fmt.Sprintf("%s:delete:%s", scopePrefix, i))
 	}
 
 	return s


### PR DESCRIPTION
This PR will add new authenticated endpoints allowing an external system to indicate that instance metadata or userdata should be deleted.

While deleting userdata might happen at any time during the lifetime of the instance, generally metadata will only get deleted when the instance is being deprovisioned.

In any case, if there is no remaining metadata or userdata for the instance as a result of the call, we need to make sure to also delete any associated `instance_ip_addresses` rows associated to the instance ID.

