### PR TITLE
Add support for configuring gin's trusted proxies setting

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -72,6 +72,10 @@ func init() {
 
 	serveCmd.Flags().String("oidc-username-claim", "", "additional fields to output in logs from the JWT token, ex (email)")
 	viperBindFlag("oidc.claims.username", serveCmd.Flags().Lookup("oidc-username-claim"))
+
+	// Misc serve flags
+	serveCmd.Flags().StringSlice("gin-trusted-proxies", []string{}, "Comma-separated list of IP addresses, like `\"192.168.1.1,10.0.0.1\"`. When running the Metadata Service behind something like a reverse proxy or load balancer, you may need to set this so that gin's `(*Context).ClientIP()` method returns a value provided by the proxy in a header like `X-Forwarded-For`.")
+	viperBindFlag("gin.trustedproxies", serveCmd.Flags().Lookup("gin-trusted-proxies"))
 }
 
 func serve() {
@@ -93,6 +97,7 @@ func serve() {
 			RolesClaim:    viper.GetString("oidc.claims.roles"),
 			UsernameClaim: viper.GetString("oidc.claims.username"),
 		},
+		TrustedProxies: viper.GetStringSlice("gin.trustedproxies"),
 	}
 
 	if err := hs.Run(); err != nil {

--- a/internal/httpsrv/server.go
+++ b/internal/httpsrv/server.go
@@ -21,11 +21,12 @@ import (
 
 // Server contains the HTTP server configuration
 type Server struct {
-	Logger     *zap.Logger
-	Listen     string
-	Debug      bool
-	DB         *sqlx.DB
-	AuthConfig ginjwt.AuthConfig
+	Logger         *zap.Logger
+	Listen         string
+	Debug          bool
+	DB             *sqlx.DB
+	AuthConfig     ginjwt.AuthConfig
+	TrustedProxies []string
 }
 
 var (
@@ -47,6 +48,14 @@ func (s *Server) setup() *gin.Engine {
 
 	// Setup default gin router
 	r := gin.New()
+
+	// Set the trusted proxies, if they were specified by config
+	if len(s.TrustedProxies) > 0 {
+		err = r.SetTrustedProxies(s.TrustedProxies)
+		if err != nil {
+			s.Logger.Sugar().Fatal("failed to set gin trusted proxies", "error", err)
+		}
+	}
 
 	r.Use(cors.New(cors.Config{
 		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"},


### PR DESCRIPTION
This is used when running the metadata service behind a reverse proxy or load balancer. If the connection is coming from an IP specified in the list, then headers like `X-Forwarded-For` will be trusted when resolving the true client IP.