### PR TITLE
Metadata Lookup Service client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	go.opentelemetry.io/otel/exporters/jaeger v1.8.0
 	go.opentelemetry.io/otel/sdk v1.8.0
 	go.uber.org/zap v1.21.0
+	golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094
 )
 
 require (
@@ -83,10 +84,11 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167 // indirect
-	golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
+	golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df // indirect
+	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
+	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,7 @@ cloud.google.com/go v0.94.1/go.mod h1:qAlAugsXlC+JWO+Bke5vCtc9ONxjQT3drlTTnAplMW
 cloud.google.com/go v0.97.0/go.mod h1:GF7l59pYBVlXQIBLx3a761cZ41F9bBH3JUlihCt2Udc=
 cloud.google.com/go v0.99.0/go.mod h1:w0Xx2nLzqWJPuozYQX+hFfCSI8WioryfRDzkoI/Y2ZA=
 cloud.google.com/go v0.100.2/go.mod h1:4Xra9TjzAeYHrl5+oeLlzbM2k3mjVhZh4UqTZ//w99A=
+cloud.google.com/go v0.102.0/go.mod h1:oWcCzKlqJ5zgHQt9YsaeTY9KzIvjyy0ArmiBUgpQ+nc=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=
@@ -41,11 +42,13 @@ cloud.google.com/go/compute v1.3.0/go.mod h1:cCZiE1NHEtai4wiufUhW8I8S1JKkAnhnQJW
 cloud.google.com/go/compute v1.5.0/go.mod h1:9SMHyhJlzhlkJqrPAc839t2BZFTSk6Jdj6mkzQJeu0M=
 cloud.google.com/go/compute v1.6.0/go.mod h1:T29tfhtVbq1wvAPo0E3+7vhgmkOYeXjhFvz/FMzPu0s=
 cloud.google.com/go/compute v1.6.1/go.mod h1:g85FgpzFvNULZ+S8AYq87axRKuf2Kh7deLqV/jJ3thU=
+cloud.google.com/go/compute v1.7.0/go.mod h1:435lt8av5oL9P3fv1OEzSbSUe+ybHXGMPQHHZWZxy9U=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
 cloud.google.com/go/firestore v1.6.0/go.mod h1:afJwI0vaXwAG54kI7A//lP/lSPDkQORQuMkv56TxEPU=
 cloud.google.com/go/firestore v1.6.1/go.mod h1:asNXNOzBdyVQmEU+ggO8UPodTkEVFW5Qx+rwHnAz+EY=
+cloud.google.com/go/iam v0.3.0/go.mod h1:XzJPvDayI+9zsASAFO68Hk07u3z+f+JrT2xXNdp4bnY=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
@@ -56,6 +59,7 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
+cloud.google.com/go/storage v1.22.1/go.mod h1:S8N1cAStu7BOeFfE8KAQzmyyLkK8p/vmRq6kuBTW58Y=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0/go.mod h1:h6H6c8enJmmocHUbLiiGY6sx7f9i+X3m1CHdd5c6Rdw=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0/go.mod h1:HcM1YX14R7CJcghJGOYCgdezslRSVzqwLf/q+4Y2r/0=
@@ -318,6 +322,7 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/googleapis/enterprise-certificate-proxy v0.0.0-20220520183353-fd19c99a87aa/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
@@ -325,6 +330,7 @@ github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0
 github.com/googleapis/gax-go/v2 v2.2.0/go.mod h1:as02EH8zWkzwUoLbBaFeQ+arQaj/OthfcblKl4IGNaM=
 github.com/googleapis/gax-go/v2 v2.3.0/go.mod h1:b8LNqSzNabLiUpXKkY7HAR5jr6bIT99EXz9pXxye9YM=
 github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK9wbMD5+iXC6c=
+github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -896,8 +902,10 @@ golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220325170049-de3da57026de/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 h1:NWy5+hlRbC7HK+PmcXVUmW1IMyFce7to56IUvhUFm7Y=
 golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e h1:TsQ7F31D3bUCLeqPT0u+yjp1guoArKaNKmCr22PYgTQ=
+golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -919,6 +927,9 @@ golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
+golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb/go.mod h1:jaDAt6Dkxork7LmZnYtzbRWj0W47D86a3TGe0YHBvmE=
+golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094 h1:2o1E+E8TpNLklK9nHiPiK1uzIYrIHt+cQx3ynCwq9V8=
+golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -931,6 +942,7 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1024,9 +1036,11 @@ golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220502124256-b6088ccd6cba/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d h1:Zu/JngovGLVi6t2J3nmAf3AoTDwuzw85YZ3b9o4yU7s=
+golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
@@ -1117,8 +1131,9 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df h1:5Pf6pFKu98ODmgnpvkJ3kFUOQGGLIzLIkbzUHp47618=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f h1:uF6paiQQebLeSXkrTqHqz0MXhXXS1KgF41eUdBNvxK0=
+golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
@@ -1158,13 +1173,16 @@ google.golang.org/api v0.71.0/go.mod h1:4PyU6e6JogV1f9eA4voyrTY2batOLdgZ5qZ5HOCc
 google.golang.org/api v0.74.0/go.mod h1:ZpfMZOVRMywNyvJFeqL9HRWBgAuRfSjJFpe9QtRRyDs=
 google.golang.org/api v0.75.0/go.mod h1:pU9QmyHLnzlpar1Mjt4IbapUCy8J+6HD6GeELN69ljA=
 google.golang.org/api v0.78.0/go.mod h1:1Sg78yoMLOhlQTeF+ARBoytAcH1NNyyl390YMy6rKmw=
+google.golang.org/api v0.80.0/go.mod h1:xY3nI94gbvBrE0J6NHXhxOmW97HG7Khjkku6AFB3Hyg=
 google.golang.org/api v0.81.0/go.mod h1:FA6Mb/bZxj706H2j+j2d6mHEEaHBmbbWnkfvmorOCko=
+google.golang.org/api v0.84.0/go.mod h1:NTsGnUFJMYROtiquksZHBWtHfeMC7iYthki7Eq3pa8o=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -1207,6 +1225,7 @@ google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210303154014-9728d6b83eeb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20210329143202-679c6ae281ee/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
@@ -1243,7 +1262,11 @@ google.golang.org/genproto v0.0.0-20220414192740-2d67ff6cf2b4/go.mod h1:8w6bsBMX
 google.golang.org/genproto v0.0.0-20220421151946-72621c1f0bd3/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220429170224-98d788798c3e/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
+google.golang.org/genproto v0.0.0-20220518221133-4f43b3371335/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
+google.golang.org/genproto v0.0.0-20220523171625-347a074981d8/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
+google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
+google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -1276,6 +1299,7 @@ google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ5
 google.golang.org/grpc v1.45.0/go.mod h1:lN7owxKUQEqMfSyQikvvk5tf/6zMPsrK+ONuO11+0rQ=
 google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.46.2/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
+google.golang.org/grpc v1.47.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/internal/httpsrv/server.go
+++ b/internal/httpsrv/server.go
@@ -16,16 +16,19 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
+	"go.hollow.sh/metadataservice/internal/lookup"
 	v1api "go.hollow.sh/metadataservice/pkg/api/v1"
 )
 
 // Server contains the HTTP server configuration
 type Server struct {
-	Logger     *zap.Logger
-	Listen     string
-	Debug      bool
-	DB         *sqlx.DB
-	AuthConfig ginjwt.AuthConfig
+	Logger        *zap.Logger
+	Listen        string
+	Debug         bool
+	DB            *sqlx.DB
+	AuthConfig    ginjwt.AuthConfig
+	LookupEnabled bool
+	LookupClient  lookup.Client
 }
 
 var (
@@ -92,7 +95,7 @@ func (s *Server) setup() *gin.Engine {
 	r.GET("/healthz/liveness", s.livenessCheck)
 	r.GET("/healthz/readiness", s.readinessCheck)
 
-	v1Rtr := v1api.Router{AuthMW: authMW, DB: s.DB, Logger: s.Logger}
+	v1Rtr := v1api.Router{AuthMW: authMW, DB: s.DB, Logger: s.Logger, LookupEnabled: s.LookupEnabled, LookupClient: s.LookupClient}
 
 	// Host our latest version of the API under / in addition to /api/v*
 	latest := r.Group("/")

--- a/internal/lookup/client.go
+++ b/internal/lookup/client.go
@@ -1,0 +1,211 @@
+package lookup
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+
+	"go.hollow.sh/toolbox/version"
+	"go.uber.org/zap"
+)
+
+var (
+	errBaseURLParse = errors.New("could not parse base URL")
+	errNoBaseURL    = errors.New("failed to initialize: no lookup service base URL provided")
+	userAgentString = fmt.Sprintf("go-hollow-metadataservice-lookup-client (%s)", version.String())
+)
+
+// MetadataLookupResponse represents the data we expect to receive from a call
+// to the lookup service for an instance's metadata.
+type MetadataLookupResponse struct {
+	ID          string   `json:"id"`
+	IPAddresses []string `json:"ipAddresses"`
+	Metadata    string   `json:"metadata"`
+}
+
+// UserdataLookupResponse represents the data we expect to receive from a call
+// to the lookup service for an instance's userdata.
+type UserdataLookupResponse struct {
+	ID          string   `json:"id"`
+	IPAddresses []string `json:"ipAddresses"`
+	Userdata    []byte   `json:"userdata"`
+}
+
+// Client defines the methods and lookup service client should implement
+type Client interface {
+	GetMetadataByID(ctx context.Context, instanceID string) (*MetadataLookupResponse, error)
+	GetMetadataByIP(ctx context.Context, instanceIP string) (*MetadataLookupResponse, error)
+	GetUserdataByID(ctx context.Context, instanceID string) (*UserdataLookupResponse, error)
+	GetUserdataByIP(ctx context.Context, instanceIP string) (*UserdataLookupResponse, error)
+}
+
+// ServiceClient is the client used to reach out to the lookup service.
+type ServiceClient struct {
+	BaseURL *url.URL
+	client  *http.Client
+	Logger  *zap.Logger
+}
+
+// ErrorResponse represents an error response record received from the lookup
+// service.
+type ErrorResponse struct {
+	Errors []string `json:"errors,omitempty"`
+}
+
+// NewClient builds a new client for calling the lookup service. Pass in a
+// base URL for the lookup service, and an *http.Client with oauth2 creds setup
+func NewClient(logger *zap.Logger, baseURL string, httpClient *http.Client) (*ServiceClient, error) {
+	if baseURL == "" {
+		return nil, errNoBaseURL
+	}
+
+	parsedURL, err := url.Parse(baseURL)
+
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", errBaseURLParse, baseURL)
+	}
+
+	c := &ServiceClient{
+		BaseURL: parsedURL,
+		client:  httpClient,
+		Logger:  logger,
+	}
+
+	return c, nil
+}
+
+// GetMetadataByID is used to look up metadata by instance ID
+func (c *ServiceClient) GetMetadataByID(ctx context.Context, instanceID string) (*MetadataLookupResponse, error) {
+	path := path.Join("device-metadata", instanceID)
+
+	resp, err := c.getMetadata(ctx, path)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			c.Logger.Sugar().Warnf("Metadata for instance ID %s was not found in the Lookup Service", instanceID)
+		}
+	}
+
+	return resp, err
+}
+
+// GetMetadataByIP is used to look up metadata by instance IP address
+func (c *ServiceClient) GetMetadataByIP(ctx context.Context, instanceIP string) (*MetadataLookupResponse, error) {
+	path := fmt.Sprintf("device-metadata?ip_address=%s", instanceIP)
+
+	resp, err := c.getMetadata(ctx, path)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			c.Logger.Sugar().Warnf("Metadata for IP Address %s was not found in the Lookup Service", instanceIP)
+		}
+	}
+
+	return resp, err
+}
+
+// GetUserdataByID is used to look up userdata by instance ID
+func (c *ServiceClient) GetUserdataByID(ctx context.Context, instanceID string) (*UserdataLookupResponse, error) {
+	path := path.Join("device-userdata", instanceID)
+
+	resp, err := c.getUserdata(ctx, path)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			c.Logger.Sugar().Warnf("Userdata for instance ID %s was not found in the Lookup Service", instanceID)
+		}
+	}
+
+	return resp, err
+}
+
+// GetUserdataByIP is used to look up userdata by instance IP address
+func (c *ServiceClient) GetUserdataByIP(ctx context.Context, instanceIP string) (*UserdataLookupResponse, error) {
+	path := fmt.Sprintf("device-userdata?ip_address=%s", instanceIP)
+
+	resp, err := c.getUserdata(ctx, path)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			c.Logger.Sugar().Warnf("Userdata for IP Address %s was not found in the Lookup Service", instanceIP)
+		}
+	}
+
+	return resp, err
+}
+
+func newGetRequest(ctx context.Context, baseURL string, path string) (*http.Request, error) {
+	requestURL, err := url.Parse(fmt.Sprintf("%s/%s", baseURL, path))
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+	if req != nil {
+		req.Header.Set("User-Agent", userAgentString)
+	}
+
+	return req, err
+}
+
+func (c *ServiceClient) getMetadata(ctx context.Context, path string) (*MetadataLookupResponse, error) {
+	req, err := newGetRequest(ctx, c.BaseURL.String(), path)
+	if err != nil {
+		return nil, err
+	}
+
+	metadata := &MetadataLookupResponse{}
+
+	err = c.get(req, metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	return metadata, nil
+}
+
+func (c *ServiceClient) getUserdata(ctx context.Context, path string) (*UserdataLookupResponse, error) {
+	req, err := newGetRequest(ctx, c.BaseURL.String(), path)
+	if err != nil {
+		return nil, err
+	}
+
+	userdata := &UserdataLookupResponse{}
+
+	err = c.get(req, userdata)
+	if err != nil {
+		return nil, err
+	}
+
+	return userdata, nil
+}
+
+func (c *ServiceClient) get(req *http.Request, v interface{}) error {
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return ErrNotFound
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		errResp := map[string]string{}
+		err = json.NewDecoder(resp.Body).Decode(&errResp)
+
+		if err != nil {
+			if err != nil {
+				c.Logger.Sugar().Errorf("Received unexpected response status from Lookup Service: (%d), but failed to decode an error response: %v", resp.StatusCode, err)
+			} else {
+				c.Logger.Sugar().Errorf("Received unexpected response status from Lookup Service: (%d), with error: %v", resp.StatusCode, err)
+			}
+		}
+
+		return fmt.Errorf("%w: %d", ErrUnexpectedStatus, resp.StatusCode)
+	}
+
+	return json.NewDecoder(resp.Body).Decode(v)
+}

--- a/internal/lookup/client_test.go
+++ b/internal/lookup/client_test.go
@@ -1,0 +1,322 @@
+package lookup_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"go.hollow.sh/metadataservice/internal/lookup"
+)
+
+func lookupMetadataServerMock(instance testInstance) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := instance.MetadataResponse()
+
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func lookupUserdataServerMock(instance testInstance) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := instance.UserdataResponse()
+
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func lookupServerWithStatusMock(status int, body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		if len(body) > 0 {
+			fmt.Fprint(w, body)
+		}
+	}))
+}
+
+func lookupServerForbiddenMock() *httptest.Server {
+	return lookupServerWithStatusMock(http.StatusForbidden, `{"message": "invalid auth token"}`)
+}
+
+func TestNewClient(t *testing.T) {
+	// NewClient returns an error if an empty baseURL string is provided
+	_, err := lookup.NewClient(zap.NewNop(), "", http.DefaultClient)
+	assert.NotNil(t, err)
+
+	// NewClient returns an error if the provided baseURL is not pareseable
+	_, err = lookup.NewClient(zap.NewNop(), "https://ba{uh...}=:user@shouldn't parse!", http.DefaultClient)
+	assert.NotNil(t, err)
+}
+
+func TestGetMetadataByID(t *testing.T) {
+	type testCase struct {
+		testName      string
+		ID            string
+		expectedError *error
+		expectedResp  interface{}
+		srv           *httptest.Server
+	}
+
+	var testCases = []testCase{
+		{
+			testName:      "unknown instance ID",
+			ID:            "badid",
+			expectedError: &lookup.ErrNotFound,
+			expectedResp:  nil,
+			srv:           lookupServerWithStatusMock(404, `{"errors": ["not found"]}`),
+		},
+		{
+			testName:      "credentials error - access forbidden",
+			ID:            "badcreds",
+			expectedError: &lookup.ErrUnexpectedStatus,
+			expectedResp:  nil,
+			srv:           lookupServerForbiddenMock(),
+		},
+		{
+			testName:      "instance 0 test",
+			ID:            testInstances[0].ID,
+			expectedError: nil,
+			expectedResp:  testInstances[0].MetadataResponse(),
+			srv:           lookupMetadataServerMock(testInstances[0]),
+		},
+		{
+			testName:      "instance 1 test",
+			ID:            testInstances[1].ID,
+			expectedError: nil,
+			expectedResp:  testInstances[1].MetadataResponse(),
+			srv:           lookupMetadataServerMock(testInstances[1]),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			defer tc.srv.Close()
+
+			client, err := lookup.NewClient(zap.NewNop(), tc.srv.URL, http.DefaultClient)
+			if err != nil {
+				t.Errorf("error getting lookup service client: %v\n", err)
+			}
+
+			resp, err := client.GetMetadataByID(context.TODO(), tc.ID)
+
+			if tc.expectedError != nil {
+				assert.ErrorIs(t, err, *tc.expectedError)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			if tc.expectedResp != nil {
+				assert.NotNil(t, resp)
+				assert.Equal(t, tc.expectedResp, *resp)
+			} else {
+				assert.Nil(t, resp)
+			}
+		})
+	}
+}
+
+func TestGetMetadataByIP(t *testing.T) {
+	type testCase struct {
+		testName      string
+		IPAddress     string
+		expectedError *error
+		expectedResp  interface{}
+		srv           *httptest.Server
+	}
+
+	var testCases = []testCase{
+		{
+			testName:      "unknown instance IP",
+			IPAddress:     "127.0.0.1",
+			expectedError: &lookup.ErrNotFound,
+			expectedResp:  nil,
+			srv:           lookupServerWithStatusMock(404, `{"errors": ["not found"]}`),
+		},
+		{
+			testName:      "credentials error - access forbidden",
+			IPAddress:     "192.168.0.1",
+			expectedError: &lookup.ErrUnexpectedStatus,
+			expectedResp:  nil,
+			srv:           lookupServerForbiddenMock(),
+		},
+		{
+			testName:      "instance 0 test",
+			IPAddress:     testInstances[0].IPAddresses[0],
+			expectedError: nil,
+			expectedResp:  testInstances[0].MetadataResponse(),
+			srv:           lookupMetadataServerMock(testInstances[0]),
+		},
+		{
+			testName:      "instance 1 test",
+			IPAddress:     testInstances[1].IPAddresses[0],
+			expectedError: nil,
+			expectedResp:  testInstances[1].MetadataResponse(),
+			srv:           lookupMetadataServerMock(testInstances[1]),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			defer tc.srv.Close()
+
+			client, err := lookup.NewClient(zap.NewNop(), tc.srv.URL, http.DefaultClient)
+			if err != nil {
+				t.Errorf("error getting lookup service client: %v\n", err)
+			}
+
+			resp, err := client.GetMetadataByIP(context.TODO(), tc.IPAddress)
+
+			if tc.expectedError != nil {
+				assert.ErrorIs(t, err, *tc.expectedError)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			if tc.expectedResp != nil {
+				assert.NotNil(t, resp)
+				assert.Equal(t, tc.expectedResp, *resp)
+			} else {
+				assert.Nil(t, resp)
+			}
+		})
+	}
+}
+
+func TestGetUserdataByID(t *testing.T) {
+	type testCase struct {
+		testName      string
+		ID            string
+		expectedError *error
+		expectedResp  interface{}
+		srv           *httptest.Server
+	}
+
+	var testCases = []testCase{
+		{
+			testName:      "unknown instance ID",
+			ID:            "badid",
+			expectedError: &lookup.ErrNotFound,
+			expectedResp:  nil,
+			srv:           lookupServerWithStatusMock(404, `{"errors": ["not found"]}`),
+		},
+		{
+			testName:      "credentials error - access forbidden",
+			ID:            "badcreds",
+			expectedError: &lookup.ErrUnexpectedStatus,
+			expectedResp:  nil,
+			srv:           lookupServerForbiddenMock(),
+		},
+		{
+			testName:      "instance 0 test",
+			ID:            testInstances[0].ID,
+			expectedError: nil,
+			expectedResp:  testInstances[0].UserdataResponse(),
+			srv:           lookupUserdataServerMock(testInstances[0]),
+		},
+		{
+			testName:      "instance 1 test",
+			ID:            testInstances[1].ID,
+			expectedError: nil,
+			expectedResp:  testInstances[1].UserdataResponse(),
+			srv:           lookupUserdataServerMock(testInstances[1]),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			defer tc.srv.Close()
+
+			client, err := lookup.NewClient(zap.NewNop(), tc.srv.URL, http.DefaultClient)
+			if err != nil {
+				t.Errorf("error getting lookup service client: %v\n", err)
+			}
+
+			resp, err := client.GetUserdataByID(context.TODO(), tc.ID)
+
+			if tc.expectedError != nil {
+				assert.ErrorIs(t, err, *tc.expectedError)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			if tc.expectedResp != nil {
+				assert.NotNil(t, resp)
+				assert.Equal(t, tc.expectedResp, *resp)
+			} else {
+				assert.Nil(t, resp)
+			}
+		})
+	}
+}
+
+func TestGetUserdataByIP(t *testing.T) {
+	type testCase struct {
+		testName      string
+		IPAddress     string
+		expectedError *error
+		expectedResp  interface{}
+		srv           *httptest.Server
+	}
+
+	var testCases = []testCase{
+		{
+			testName:      "unknown instance IP",
+			IPAddress:     "127.0.0.1",
+			expectedError: &lookup.ErrNotFound,
+			expectedResp:  nil,
+			srv:           lookupServerWithStatusMock(404, `{"errors": ["not found"]}`),
+		},
+		{
+			testName:      "credentials error - access forbidden",
+			IPAddress:     "192.168.0.1",
+			expectedError: &lookup.ErrUnexpectedStatus,
+			expectedResp:  nil,
+			srv:           lookupServerForbiddenMock(),
+		},
+		{
+			testName:      "instance 0 test",
+			IPAddress:     testInstances[0].IPAddresses[0],
+			expectedError: nil,
+			expectedResp:  testInstances[0].UserdataResponse(),
+			srv:           lookupUserdataServerMock(testInstances[0]),
+		},
+		{
+			testName:      "instance 1 test",
+			IPAddress:     testInstances[1].IPAddresses[0],
+			expectedError: nil,
+			expectedResp:  testInstances[1].UserdataResponse(),
+			srv:           lookupUserdataServerMock(testInstances[1]),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			defer tc.srv.Close()
+
+			client, err := lookup.NewClient(zap.NewNop(), tc.srv.URL, http.DefaultClient)
+			if err != nil {
+				t.Errorf("error getting lookup service client: %v\n", err)
+			}
+
+			resp, err := client.GetUserdataByIP(context.TODO(), tc.IPAddress)
+
+			if tc.expectedError != nil {
+				assert.ErrorIs(t, err, *tc.expectedError)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			if tc.expectedResp != nil {
+				assert.NotNil(t, resp)
+				assert.Equal(t, tc.expectedResp, *resp)
+			} else {
+				assert.Nil(t, resp)
+			}
+		})
+	}
+}

--- a/internal/lookup/doc.go
+++ b/internal/lookup/doc.go
@@ -1,0 +1,3 @@
+// Package lookup provides the client used to call out to a helper
+// "metadata lookup" service via HTTP.
+package lookup // import go.hollow.sh/metadataservice/internal/lookup

--- a/internal/lookup/lookup.go
+++ b/internal/lookup/lookup.go
@@ -1,0 +1,125 @@
+package lookup
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/volatiletech/null/v8"
+	"github.com/volatiletech/sqlboiler/v4/types"
+	"go.uber.org/zap"
+
+	"go.hollow.sh/metadataservice/internal/models"
+	"go.hollow.sh/metadataservice/internal/upserter"
+)
+
+var (
+	// ErrUnexpectedStatus indicates to the caller that the upstream lookup service
+	// returned an HTTP response status code our client wasn't able to handle. This
+	// may indicate errors like the upstream service is temporarily unavailable, or
+	// our authentication credentials were not valid.
+	ErrUnexpectedStatus = errors.New("unexpectedStatusError")
+
+	// ErrNotFound indicates to the caller that the upstream lookup service
+	// returned an HTTP 404 status code, meaning that whatever instance ID or
+	// IP address we specified was not known by the upstream service.
+	ErrNotFound = errors.New("notFoundError")
+
+	errNilClient = errors.New("client can't be nil")
+)
+
+// MetadataSyncByID calls out to the metadata lookup service and
+// attempts to locate metadata for the instance with the given ID. If found,
+// it will create new records in the database for the instance IP addresses
+// and metadata.
+func MetadataSyncByID(ctx context.Context, db *sqlx.DB, logger *zap.Logger, client Client, id string) (*models.InstanceMetadatum, error) {
+	if client == nil {
+		return nil, errNilClient
+	}
+
+	resp, err := client.GetMetadataByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return storeMetadata(ctx, db, logger, resp)
+}
+
+// MetadataSyncByIP calls out to the metadata lookup service and
+// attempts to locate metadata for the instance with the given IP address. If
+// found, it will create new records in database for the instance IP addresses
+// and metadata.
+func MetadataSyncByIP(ctx context.Context, db *sqlx.DB, logger *zap.Logger, client Client, ipAddress string) (*models.InstanceMetadatum, error) {
+	if client == nil {
+		return nil, errNilClient
+	}
+
+	resp, err := client.GetMetadataByIP(ctx, ipAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return storeMetadata(ctx, db, logger, resp)
+}
+
+// UserdataSyncByID calls out to the metadata lookup service and
+// attempts to locate userdata for the instance with the given ID. If found,
+// it will create new records in the database for the instance IP addresses
+// and userdata.
+func UserdataSyncByID(ctx context.Context, db *sqlx.DB, logger *zap.Logger, client Client, id string) (*models.InstanceUserdatum, error) {
+	if client == nil {
+		return nil, errNilClient
+	}
+
+	resp, err := client.GetUserdataByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return storeUserdata(ctx, db, logger, resp)
+}
+
+// UserdataSyncByIP calls out to the metadata lookup service and
+// attempts to locate userdata for the instance with the given IP address. If
+// found, it will create new records in the database for the instance IP
+// addresses and userdata.
+func UserdataSyncByIP(ctx context.Context, db *sqlx.DB, logger *zap.Logger, client Client, ipAddress string) (*models.InstanceUserdatum, error) {
+	if client == nil {
+		return nil, errNilClient
+	}
+
+	resp, err := client.GetUserdataByID(ctx, ipAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return storeUserdata(ctx, db, logger, resp)
+}
+
+func storeMetadata(ctx context.Context, db *sqlx.DB, logger *zap.Logger, lookupResp *MetadataLookupResponse) (*models.InstanceMetadatum, error) {
+	newInstanceMetadata := &models.InstanceMetadatum{
+		ID:       lookupResp.ID,
+		Metadata: types.JSON(lookupResp.Metadata),
+	}
+
+	err := upserter.UpsertMetadata(ctx, db, logger, lookupResp.ID, lookupResp.IPAddresses, newInstanceMetadata)
+	if err != nil {
+		return nil, err
+	}
+
+	return newInstanceMetadata, nil
+}
+
+func storeUserdata(ctx context.Context, db *sqlx.DB, logger *zap.Logger, lookupResp *UserdataLookupResponse) (*models.InstanceUserdatum, error) {
+	newInstanceUserdata := &models.InstanceUserdatum{
+		ID:       lookupResp.ID,
+		Userdata: null.NewBytes(lookupResp.Userdata, true),
+	}
+
+	err := upserter.UpsertUserdata(ctx, db, logger, lookupResp.ID, lookupResp.IPAddresses, newInstanceUserdata)
+	if err != nil {
+		return nil, err
+	}
+
+	return newInstanceUserdata, nil
+}

--- a/internal/lookup/lookup_test.go
+++ b/internal/lookup/lookup_test.go
@@ -1,0 +1,300 @@
+package lookup_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"go.hollow.sh/metadataservice/internal/dbtools"
+	"go.hollow.sh/metadataservice/internal/lookup"
+)
+
+type mockLookupClient struct {
+	MetadataResponse lookup.MetadataLookupResponse
+	UserdataResponse lookup.UserdataLookupResponse
+	Error            error
+}
+
+func (m *mockLookupClient) GetMetadataByID(_ context.Context, _ string) (*lookup.MetadataLookupResponse, error) {
+	return &m.MetadataResponse, m.Error
+}
+
+func (m *mockLookupClient) GetMetadataByIP(_ context.Context, _ string) (*lookup.MetadataLookupResponse, error) {
+	return &m.MetadataResponse, m.Error
+}
+
+func (m *mockLookupClient) GetUserdataByID(_ context.Context, _ string) (*lookup.UserdataLookupResponse, error) {
+	return &m.UserdataResponse, m.Error
+}
+
+func (m *mockLookupClient) GetUserdataByIP(_ context.Context, _ string) (*lookup.UserdataLookupResponse, error) {
+	return &m.UserdataResponse, m.Error
+}
+
+type testInstance struct {
+	ID          string
+	IPAddresses []string
+	Metadata    string
+	Userdata    []byte
+}
+
+func (ti *testInstance) MetadataResponse() lookup.MetadataLookupResponse {
+	return lookup.MetadataLookupResponse{
+		ID:          ti.ID,
+		IPAddresses: ti.IPAddresses,
+		Metadata:    ti.Metadata,
+	}
+}
+
+func (ti *testInstance) UserdataResponse() lookup.UserdataLookupResponse {
+	return lookup.UserdataLookupResponse{
+		ID:          ti.ID,
+		IPAddresses: ti.IPAddresses,
+		Userdata:    ti.Userdata,
+	}
+}
+
+var testInstances = []testInstance{
+	{
+		ID:          "8dcf8e72-48a4-415c-afe2-6ba67bd2c956",
+		IPAddresses: []string{"1.2.3.4"},
+		Metadata:    `{"some":"metadata for instance 0"}`,
+		Userdata:    []byte("some userdata for instance 0"),
+	},
+	{
+		ID:          "7db4d541-a669-4860-9b32-b7f17fbe4136",
+		IPAddresses: []string{"9.8.7.6"},
+		Metadata:    `{"some":"metadata for instance 1"}`,
+		Userdata:    []byte("some userdata for instance 1"),
+	},
+}
+
+func TestFetchMetadataByIDAndStoreNilClient(t *testing.T) {
+	testDB := dbtools.DatabaseTest(t)
+	metadata, err := lookup.MetadataSyncByID(context.TODO(), testDB, zap.NewNop(), nil, "abc123")
+	assert.NotNil(t, err)
+	assert.Equal(t, "client can't be nil", err.Error())
+	assert.Nil(t, metadata)
+}
+
+func TestFetchMetadataByIDAndStore(t *testing.T) {
+	type testCase struct {
+		ID               string
+		ResponseError    error
+		MetadataResponse lookup.MetadataLookupResponse
+	}
+
+	var testCases = []testCase{
+		{
+			ID:            "abc123",
+			ResponseError: lookup.ErrNotFound,
+		},
+		{
+			ID:            "def456",
+			ResponseError: lookup.ErrUnexpectedStatus,
+		},
+		{
+			ID:               testInstances[0].ID,
+			MetadataResponse: testInstances[0].MetadataResponse(),
+		},
+		{
+			ID:               testInstances[1].ID,
+			MetadataResponse: testInstances[1].MetadataResponse(),
+		},
+	}
+
+	testDB := dbtools.DatabaseTest(t)
+
+	for _, tc := range testCases {
+		mockClient := mockLookupClient{
+			MetadataResponse: tc.MetadataResponse,
+			Error:            tc.ResponseError,
+		}
+
+		metadata, err := lookup.MetadataSyncByID(context.TODO(), testDB, zap.NewNop(), &mockClient, tc.ID)
+		if tc.ResponseError != nil {
+			assert.NotNil(t, err)
+			assert.ErrorIs(t, err, tc.ResponseError)
+		} else {
+			assert.Nil(t, err)
+			assert.NotNil(t, metadata)
+			assert.Equal(t, metadata.ID, tc.ID)
+		}
+	}
+}
+
+func TestFetchMetadataByIPAndStoreNilClient(t *testing.T) {
+	testDB := dbtools.DatabaseTest(t)
+	metadata, err := lookup.MetadataSyncByIP(context.TODO(), testDB, zap.NewNop(), nil, "1.2.3.4")
+	assert.NotNil(t, err)
+	assert.Equal(t, "client can't be nil", err.Error())
+	assert.Nil(t, metadata)
+}
+
+func TestFetchMetadataByIPAndStore(t *testing.T) {
+	type testCase struct {
+		ID               string
+		IPAddress        string
+		ResponseError    error
+		MetadataResponse lookup.MetadataLookupResponse
+	}
+
+	var testCases = []testCase{
+		{
+			IPAddress:     "1.2.3.4",
+			ResponseError: lookup.ErrNotFound,
+		},
+		{
+			ID:            "def456",
+			ResponseError: lookup.ErrUnexpectedStatus,
+		},
+	}
+
+	// Add tests for each testInstance IP address
+	for _, testInstance := range testInstances {
+		for _, ip := range testInstance.IPAddresses {
+			tc := testCase{
+				ID:               testInstance.ID,
+				IPAddress:        ip,
+				MetadataResponse: testInstance.MetadataResponse(),
+			}
+
+			testCases = append(testCases, tc)
+		}
+	}
+
+	testDB := dbtools.DatabaseTest(t)
+
+	for _, tc := range testCases {
+		mockClient := mockLookupClient{
+			MetadataResponse: tc.MetadataResponse,
+			Error:            tc.ResponseError,
+		}
+
+		metadata, err := lookup.MetadataSyncByIP(context.TODO(), testDB, zap.NewNop(), &mockClient, tc.IPAddress)
+		if tc.ResponseError != nil {
+			assert.NotNil(t, err)
+			assert.ErrorIs(t, err, tc.ResponseError)
+		} else {
+			assert.Nil(t, err)
+			assert.NotNil(t, metadata)
+			assert.Equal(t, metadata.ID, tc.ID)
+		}
+	}
+}
+
+func TestFetchUserdataByIDAndStoreNilClient(t *testing.T) {
+	testDB := dbtools.DatabaseTest(t)
+	userdata, err := lookup.UserdataSyncByID(context.TODO(), testDB, zap.NewNop(), nil, "abc123")
+	assert.NotNil(t, err)
+	assert.Equal(t, "client can't be nil", err.Error())
+	assert.Nil(t, userdata)
+}
+
+func TestFetchUserdataByIDAndStore(t *testing.T) {
+	type testCase struct {
+		ID               string
+		ResponseError    error
+		UserdataResponse lookup.UserdataLookupResponse
+	}
+
+	var testCases = []testCase{
+		{
+			ID:            "abc123",
+			ResponseError: lookup.ErrNotFound,
+		},
+		{
+			ID:            "def456",
+			ResponseError: lookup.ErrUnexpectedStatus,
+		},
+		{
+			ID:               testInstances[0].ID,
+			UserdataResponse: testInstances[0].UserdataResponse(),
+		},
+		{
+			ID:               testInstances[1].ID,
+			UserdataResponse: testInstances[1].UserdataResponse(),
+		},
+	}
+
+	testDB := dbtools.DatabaseTest(t)
+
+	for _, tc := range testCases {
+		mockClient := mockLookupClient{
+			UserdataResponse: tc.UserdataResponse,
+			Error:            tc.ResponseError,
+		}
+
+		userdata, err := lookup.UserdataSyncByID(context.TODO(), testDB, zap.NewNop(), &mockClient, tc.ID)
+		if tc.ResponseError != nil {
+			assert.NotNil(t, err)
+			assert.ErrorIs(t, err, tc.ResponseError)
+		} else {
+			assert.Nil(t, err)
+			assert.NotNil(t, userdata)
+			assert.Equal(t, userdata.ID, tc.ID)
+		}
+	}
+}
+
+func TestFetchUserdataByIPAndStoreNilClient(t *testing.T) {
+	testDB := dbtools.DatabaseTest(t)
+	userdata, err := lookup.UserdataSyncByIP(context.TODO(), testDB, zap.NewNop(), nil, "1.2.3.4")
+	assert.NotNil(t, err)
+	assert.Equal(t, "client can't be nil", err.Error())
+	assert.Nil(t, userdata)
+}
+
+func TestFetchUserdataByIPAndStore(t *testing.T) {
+	type testCase struct {
+		ID               string
+		IPAddress        string
+		ResponseError    error
+		UserdataResponse lookup.UserdataLookupResponse
+	}
+
+	var testCases = []testCase{
+		{
+			IPAddress:     "1.2.3.4",
+			ResponseError: lookup.ErrNotFound,
+		},
+		{
+			ID:            "def456",
+			ResponseError: lookup.ErrUnexpectedStatus,
+		},
+	}
+
+	// Add tests for each testInstance IP address
+	for _, testInstance := range testInstances {
+		for _, ip := range testInstance.IPAddresses {
+			tc := testCase{
+				ID:               testInstance.ID,
+				IPAddress:        ip,
+				UserdataResponse: testInstance.UserdataResponse(),
+			}
+
+			testCases = append(testCases, tc)
+		}
+	}
+
+	testDB := dbtools.DatabaseTest(t)
+
+	for _, tc := range testCases {
+		mockClient := mockLookupClient{
+			UserdataResponse: tc.UserdataResponse,
+			Error:            tc.ResponseError,
+		}
+
+		userdata, err := lookup.UserdataSyncByIP(context.TODO(), testDB, zap.NewNop(), &mockClient, tc.IPAddress)
+		if tc.ResponseError != nil {
+			assert.NotNil(t, err)
+			assert.ErrorIs(t, err, tc.ResponseError)
+		} else {
+			assert.Nil(t, err)
+			assert.NotNil(t, userdata)
+			assert.Equal(t, userdata.ID, tc.ID)
+		}
+	}
+}

--- a/internal/middleware/identify_instance.go
+++ b/internal/middleware/identify_instance.go
@@ -17,6 +17,11 @@ import (
 // instance has been identified.
 const ContextKeyInstanceID = "instance-id"
 
+// ContextKeyRequestorIP is the magic string set in the gin.Context key/value
+// store used for storing the IP address of a caller making a request for
+// metadata or userdata.
+const ContextKeyRequestorIP = "requestor-ip-address"
+
 // When a request comes in to the /metadata or /userdata endpoints (or the 2009-04-04/* variants)
 // we need to identify the instance making the request.
 // There's 2 ways to do this:
@@ -54,6 +59,8 @@ func IdentifyInstanceByIP(db *sqlx.DB) gin.HandlerFunc {
 		// But if a proxy is sitting in front of this service, RemoteAddr will be
 		// the IP of the proxy, and not the requestor.
 		address = c.ClientIP()
+
+		c.Set(ContextKeyRequestorIP, address)
 
 		instanceIPAddress, err = models.InstanceIPAddresses(qm.Where("address >>= ?::inet", address)).One(c, db)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {

--- a/internal/upserter/doc.go
+++ b/internal/upserter/doc.go
@@ -1,0 +1,4 @@
+// Package upserter provides a utility used to upsert (insert or update)
+// instance_metadata and instance_userdata records, along with the
+// instance_ip_addresses rows associated to the instance ID and IP addresses.
+package upserter // import go.hollow.sh/metadataservice/internal/upserter

--- a/internal/upserter/upserter.go
+++ b/internal/upserter/upserter.go
@@ -1,0 +1,188 @@
+package upserter
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/volatiletech/sqlboiler/v4/boil"
+	"go.uber.org/zap"
+
+	"go.hollow.sh/metadataservice/internal/models"
+)
+
+// RecordUpserter is a function defined in by each metadata or userdata upsert
+// handler function and passed into the general handleUpsertRequest function.
+// This lets us share the common functionality shared between both, like
+// handling conflicting IPs, adding new instance_ip_address rows, and
+// removing stale instance_ip_address rows can be handled generically while
+// delegating the specific implementation for handling upserting metadata
+// or userdata records back to the calling method.
+type RecordUpserter func(c context.Context, exec boil.ContextExecutor) error
+
+// UpsertMetadata is used to upsert (update or insert) an instance_metadata
+// record, along with managing inserting new instance_ip_addresses rows and
+// removing conflicting or stale instance_ip_addresses rows.
+func UpsertMetadata(ctx context.Context, db *sqlx.DB, logger *zap.Logger, id string, ipAddresses []string, metadata *models.InstanceMetadatum) error {
+	metadataUpserter := func(c context.Context, exec boil.ContextExecutor) error {
+		return metadata.Upsert(c, exec, true, []string{"id"}, boil.Whitelist("metadata"), boil.Infer())
+	}
+
+	return doUpsert(ctx, db, logger, id, ipAddresses, metadataUpserter)
+}
+
+// UpsertUserdata is used to upsert (update or insert) an instance_userdata
+// record, along with managing inserting new instance_ip_addresses rows and
+// removing conflicting or stale instance_ip_addresses rows.
+func UpsertUserdata(ctx context.Context, db *sqlx.DB, logger *zap.Logger, id string, ipAddresses []string, userdata *models.InstanceUserdatum) error {
+	userdataUpserter := func(c context.Context, exec boil.ContextExecutor) error {
+		return userdata.Upsert(c, exec, true, []string{"id"}, boil.Whitelist("userdata"), boil.Infer())
+	}
+
+	return doUpsert(ctx, db, logger, id, ipAddresses, userdataUpserter)
+}
+
+// doUpsert handles the functionality common to inserting or updating both
+// metadata and userdata records. Namely, handling conflicting or stale
+// (in the case of an update) IP address associations.
+func doUpsert(ctx context.Context, db *sqlx.DB, logger *zap.Logger, id string, ipAddresses []string, upsertRecordFunc RecordUpserter) error {
+	// Step 1
+	// Look for any conflicting IP addresses (IPs already present and associated
+	// with a *different* Instance ID)
+	conflictIPs, err := models.InstanceIPAddresses(models.InstanceIPAddressWhere.Address.IN(ipAddresses), models.InstanceIPAddressWhere.InstanceID.NEQ(id)).All(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	// Step 2
+	// Look up any existing instance_ip_addresses rows for the provided instance ID
+	instanceIPAddresses, err := models.InstanceIPAddresses(models.InstanceIPAddressWhere.InstanceID.EQ(id)).All(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	// Step 2.5.a
+	// Find "stale" InstanceIPAddress rows for this instance. That is, select
+	// rows from the instanceIPAddresses result which don't have a corresponding
+	// entry in the list of IP Addresses supplied in the call.
+	var staleInstanceIPAddreses models.InstanceIPAddressSlice
+
+	for _, instanceIP := range instanceIPAddresses {
+		found := false
+
+		for _, IP := range ipAddresses {
+			if strings.EqualFold(instanceIP.Address, IP) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			staleInstanceIPAddreses = append(staleInstanceIPAddreses, instanceIP)
+		}
+	}
+
+	// Step 2.5.b
+	// Find new IP Addresses that were specified in the call that aren't
+	// currently associated to the instance.
+	var newInstanceIPAddresses models.InstanceIPAddressSlice
+
+	for _, IP := range ipAddresses {
+		found := false
+
+		for _, instanceIP := range instanceIPAddresses {
+			if strings.EqualFold(IP, instanceIP.Address) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			newRecord := &models.InstanceIPAddress{
+				InstanceID: id,
+				Address:    IP,
+			}
+			newInstanceIPAddresses = append(newInstanceIPAddresses, newRecord)
+		}
+	}
+
+	// Step 3
+	// Kick off the DB transaction
+	txErr := false
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	// If there's an error, we'll want to roll back the transaction.
+	defer func() {
+		if txErr {
+			err := tx.Rollback()
+			if err != nil {
+				logger.Sugar().Error("Could not roll back transaction", "error", err)
+			}
+		}
+	}()
+
+	// Step 4
+	// Remove any instance_ip_address rows for the specified IP addresses that
+	// are currently associated to a *different* instance ID
+	for _, conflictingIP := range conflictIPs {
+		// TODO: Maybe remove instance_metadata and instance_userdata records for the "old" instance ID(s)?
+		// Potentially after checking to see if this IP was the *last* IP address associated to the
+		// "old" instance ID?
+		_, err := conflictingIP.Delete(ctx, tx)
+		if err != nil {
+			txErr = true
+
+			return err
+		}
+	}
+
+	// Step 5
+	// Remove any "stale" instance_ip_addresses rows associated to the provided
+	// instnace_id but were not specified in the call.
+	for _, staleIP := range staleInstanceIPAddreses {
+		_, err := staleIP.Delete(ctx, tx)
+		if err != nil {
+			txErr = true
+
+			return err
+		}
+	}
+
+	// Step 6
+	// Create instance_ip_addresses rows for any IP addresses specified in the
+	// call that aren't already associated to the provided instance_id
+	for _, newInstanceIP := range newInstanceIPAddresses {
+		err := newInstanceIP.Insert(ctx, tx, boil.Infer())
+		if err != nil {
+			txErr = true
+
+			return err
+		}
+	}
+
+	// Step 7
+	// Upsert the instance_metadata or instance_userdata table. This will create
+	// a new row with the provided instance ID and metadata or userdata if there
+	// is no current row for instance_id. If there is an existing row matching on
+	// instance_id, instead this will just update the metadata or userdata column
+	// value.
+	if err := upsertRecordFunc(ctx, tx); err != nil {
+		txErr = true
+
+		return err
+	}
+
+	// Step 8
+	// Commit our transaction
+	if err := tx.Commit(); err != nil {
+		txErr = true
+
+		return err
+	}
+
+	return nil
+}

--- a/internal/upserter/upserter_test.go
+++ b/internal/upserter/upserter_test.go
@@ -1,0 +1,316 @@
+package upserter_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/volatiletech/null/v8"
+	"github.com/volatiletech/sqlboiler/v4/types"
+	"go.uber.org/zap"
+
+	"go.hollow.sh/metadataservice/internal/dbtools"
+	"go.hollow.sh/metadataservice/internal/models"
+	"go.hollow.sh/metadataservice/internal/upserter"
+)
+
+var (
+	instanceID        = "22bc79fc-3834-40b8-b734-30bef9634939"
+	instanceIPs       = []string{"1.2.3.4", "1f00:1f00:1f00:1f00::9/127"}
+	instanceMetadata0 = `{"some":"metadata"}`
+	instanceMetadata1 = `{"some":"updated metadata"}`
+	instanceUserdata0 = "some userdata..."
+	instanceUserdata1 = "some updated userdata..."
+)
+
+// Test that upsert metadata adds a new instance_metadata row to the DB
+func TestUpsertMetadataAddsInstanceMetadataRow(t *testing.T) {
+	testDB := dbtools.DatabaseTest(t)
+
+	exists, err := models.InstanceMetadatumExists(context.TODO(), testDB, instanceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.False(t, exists)
+
+	metadata := models.InstanceMetadatum{
+		ID:       instanceID,
+		Metadata: types.JSON(instanceMetadata0),
+	}
+
+	err = upserter.UpsertMetadata(context.TODO(), testDB, zap.NewNop(), instanceID, instanceIPs, &metadata)
+	assert.Nil(t, err)
+
+	exists, err = models.InstanceMetadatumExists(context.TODO(), testDB, instanceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.True(t, exists)
+}
+
+// Test that upsert metadata adds new instance_ip_addresses rows to the DB
+func TestUpsertMetadataAddsInstanceIPAddressesRows(t *testing.T) {
+	testDB := dbtools.DatabaseTest(t)
+	metadata := models.InstanceMetadatum{
+		ID:       instanceID,
+		Metadata: types.JSON(instanceMetadata0),
+	}
+
+	instanceIPAddressesCount, err := models.InstanceIPAddresses().Count(context.TODO(), testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = upserter.UpsertMetadata(context.TODO(), testDB, zap.NewNop(), instanceID, instanceIPs, &metadata)
+	assert.Nil(t, err)
+
+	newInstanceIPAddressesCount, err := models.InstanceIPAddresses().Count(context.TODO(), testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, instanceIPAddressesCount+2, newInstanceIPAddressesCount)
+}
+
+// Test that upsert metadata updates the instance_metadata row and removes any
+// "stale" instance_ip_addresses rows. "Stale" IPs are addresses that were
+// previously associated to the instance, but weren't included in a subsequent
+// update.
+func TestUpsertMetadataRemovesStaleInstanceIPAddressesRows(t *testing.T) {
+	testDB := dbtools.DatabaseTest(t)
+	metadataInsert := models.InstanceMetadatum{
+		ID:       instanceID,
+		Metadata: types.JSON(instanceMetadata0),
+	}
+
+	metadataUpdate := models.InstanceMetadatum{
+		ID:       instanceID,
+		Metadata: types.JSON(instanceMetadata1),
+	}
+
+	// Insert the metadata record
+	err := upserter.UpsertMetadata(context.TODO(), testDB, zap.NewNop(), instanceID, instanceIPs, &metadataInsert)
+	assert.Nil(t, err)
+
+	// Check that 2 instance_ip_addresses rows were created
+	instanceIPAddresses, err := models.InstanceIPAddresses(models.InstanceIPAddressWhere.InstanceID.EQ(instanceID)).All(context.TODO(), testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 2, len(instanceIPAddresses))
+
+	// Update the metadata record
+	newIPs := instanceIPs[:1]
+	err = upserter.UpsertMetadata(context.TODO(), testDB, zap.NewNop(), instanceID, newIPs, &metadataUpdate)
+	assert.Nil(t, err)
+
+	// Check that now there is just 1 instance_ip_address row associated to the instance
+	instanceIPAddresses, err = models.InstanceIPAddresses(models.InstanceIPAddressWhere.InstanceID.EQ(instanceID)).All(context.TODO(), testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 1, len(instanceIPAddresses))
+}
+
+// Test that an upsert metadata call including IP Addresses already associated
+// to another instance ID causes the "old" rows to be removed in favor of new
+// rows for the new instance.
+func TestUpsertMetadataRemovesConflictingIPAddressesRows(t *testing.T) {
+	testDB := dbtools.DatabaseTest(t)
+	// Create an "old" record.
+	oldID := "1f36c15b-b3ef-45da-b7e8-f434287e2f03"
+	oldMetadata := models.InstanceMetadatum{
+		ID:       oldID,
+		Metadata: types.JSON(`{"old":"metadata"}`),
+	}
+
+	err := upserter.UpsertMetadata(context.TODO(), testDB, zap.NewNop(), oldID, instanceIPs, &oldMetadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify there's 2 instance_ip_addresses associated to the "old" instance ID
+	oldInstanceIPAddresses, err := models.InstanceIPAddresses(models.InstanceIPAddressWhere.InstanceID.EQ(oldID)).All(context.TODO(), testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 2, len(oldInstanceIPAddresses))
+
+	// Now upsert a new metadata record for a new instance, but with the same 2 IP addresses
+	newMetadata := models.InstanceMetadatum{
+		ID:       instanceID,
+		Metadata: types.JSON(instanceMetadata0),
+	}
+
+	err = upserter.UpsertMetadata(context.TODO(), testDB, zap.NewNop(), instanceID, instanceIPs, &newMetadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify there's 2 instance_ip_addresses associated to the "new" instance ID
+	newInstanceIPAddresses, err := models.InstanceIPAddresses(models.InstanceIPAddressWhere.InstanceID.EQ(instanceID)).All(context.TODO(), testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 2, len(newInstanceIPAddresses))
+
+	// And verify that there's now 0 instance_ip_addresses associated to the "old" instance ID
+	oldInstanceIPAddresses, err = models.InstanceIPAddresses(models.InstanceIPAddressWhere.InstanceID.EQ(oldID)).All(context.TODO(), testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 0, len(oldInstanceIPAddresses))
+}
+
+// Test that upsert userdata adds a new instance_userdata row to the DB
+func TestUpsertUserdataAddsInstanceMetadataRow(t *testing.T) {
+	testDB := dbtools.DatabaseTest(t)
+
+	exists, err := models.InstanceUserdatumExists(context.TODO(), testDB, instanceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.False(t, exists)
+
+	userdata := models.InstanceUserdatum{
+		ID:       instanceID,
+		Userdata: null.NewBytes([]byte(instanceUserdata0), true),
+	}
+
+	err = upserter.UpsertUserdata(context.TODO(), testDB, zap.NewNop(), instanceID, instanceIPs, &userdata)
+	assert.Nil(t, err)
+
+	exists, err = models.InstanceUserdatumExists(context.TODO(), testDB, instanceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.True(t, exists)
+}
+
+// Test that upsert userdata adds new instance_ip_addresses rows to the DB
+func TestUpsertUserdataAddsInstanceIPAddressesRows(t *testing.T) {
+	testDB := dbtools.DatabaseTest(t)
+	userdata := models.InstanceUserdatum{
+		ID:       instanceID,
+		Userdata: null.NewBytes([]byte(instanceUserdata0), true),
+	}
+
+	instanceIPAddressesCount, err := models.InstanceIPAddresses().Count(context.TODO(), testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = upserter.UpsertUserdata(context.TODO(), testDB, zap.NewNop(), instanceID, instanceIPs, &userdata)
+	assert.Nil(t, err)
+
+	newInstanceIPAddressesCount, err := models.InstanceIPAddresses().Count(context.TODO(), testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, instanceIPAddressesCount+2, newInstanceIPAddressesCount)
+}
+
+// Test that upsert userdata updates the instance_userdata row and removes any
+// "stale" instance_ip_addresses rows. "Stale" IPs are addresses that were
+// previously associated to the instance, but weren't included in a subsequent
+// update.
+func TestUpsertUserdataRemovesStaleInstanceIPAddressesRows(t *testing.T) {
+	testDB := dbtools.DatabaseTest(t)
+	userdataInsert := models.InstanceUserdatum{
+		ID:       instanceID,
+		Userdata: null.NewBytes([]byte(instanceUserdata0), true),
+	}
+
+	userdataUpdate := models.InstanceUserdatum{
+		ID:       instanceID,
+		Userdata: null.NewBytes([]byte(instanceUserdata1), true),
+	}
+
+	// Insert the metadata record
+	err := upserter.UpsertUserdata(context.TODO(), testDB, zap.NewNop(), instanceID, instanceIPs, &userdataInsert)
+	assert.Nil(t, err)
+
+	// Check that 2 instance_ip_addresses rows were created
+	instanceIPAddresses, err := models.InstanceIPAddresses(models.InstanceIPAddressWhere.InstanceID.EQ(instanceID)).All(context.TODO(), testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 2, len(instanceIPAddresses))
+
+	// Update the metadata record
+	newIPs := instanceIPs[:1]
+	err = upserter.UpsertUserdata(context.TODO(), testDB, zap.NewNop(), instanceID, newIPs, &userdataUpdate)
+	assert.Nil(t, err)
+
+	// Check that now there is just 1 instance_ip_address row associated to the instance
+	instanceIPAddresses, err = models.InstanceIPAddresses(models.InstanceIPAddressWhere.InstanceID.EQ(instanceID)).All(context.TODO(), testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 1, len(instanceIPAddresses))
+}
+
+// Test that an upsert userdata call including IP Addresses already associated
+// to another instance ID causes the "old" rows to be removed in favor of new
+// rows for the new instance.
+func TestUpsertUserdataRemovesConflictingIPAddressesRows(t *testing.T) {
+	testDB := dbtools.DatabaseTest(t)
+	// Create an "old" record.
+	oldID := "1f36c15b-b3ef-45da-b7e8-f434287e2f03"
+	oldMetadata := models.InstanceMetadatum{
+		ID:       oldID,
+		Metadata: types.JSON(`{"old":"metadata"}`),
+	}
+
+	err := upserter.UpsertMetadata(context.TODO(), testDB, zap.NewNop(), oldID, instanceIPs, &oldMetadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify there's 2 instance_ip_addresses associated to the "old" instance ID
+	oldInstanceIPAddresses, err := models.InstanceIPAddresses(models.InstanceIPAddressWhere.InstanceID.EQ(oldID)).All(context.TODO(), testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 2, len(oldInstanceIPAddresses))
+
+	// Now upsert a new userdata record for a new instance, but with the same 2 IP addresses
+	newUserdata := models.InstanceUserdatum{
+		ID:       instanceID,
+		Userdata: null.NewBytes([]byte(instanceUserdata0), true),
+	}
+
+	err = upserter.UpsertUserdata(context.TODO(), testDB, zap.NewNop(), instanceID, instanceIPs, &newUserdata)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify there's 2 instance_ip_addresses associated to the "new" instance ID
+	newInstanceIPAddresses, err := models.InstanceIPAddresses(models.InstanceIPAddressWhere.InstanceID.EQ(instanceID)).All(context.TODO(), testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 2, len(newInstanceIPAddresses))
+
+	// And verify that there's now 0 instance_ip_addresses associated to the "old" instance ID
+	oldInstanceIPAddresses, err = models.InstanceIPAddresses(models.InstanceIPAddressWhere.InstanceID.EQ(oldID)).All(context.TODO(), testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 0, len(oldInstanceIPAddresses))
+}

--- a/pkg/api/v1/router.go
+++ b/pkg/api/v1/router.go
@@ -1,6 +1,8 @@
 package metadataservice
 
 import (
+	"database/sql"
+	"errors"
 	"fmt"
 	"path"
 	"reflect"
@@ -13,7 +15,9 @@ import (
 
 	"go.hollow.sh/toolbox/ginjwt"
 
+	"go.hollow.sh/metadataservice/internal/lookup"
 	"go.hollow.sh/metadataservice/internal/middleware"
+	"go.hollow.sh/metadataservice/internal/models"
 )
 
 const (
@@ -49,13 +53,20 @@ const (
 
 var (
 	validate *validator.Validate
+
+	// errNotFound wraps the two sorts of "not found" errors we might encounter
+	// - the item wasn't found in the DB
+	// - the item wasn't found in the upstream lookup service
+	errNotFound = errors.New("not found")
 )
 
 // Router provides a router for the v1 API
 type Router struct {
-	AuthMW *ginjwt.Middleware
-	DB     *sqlx.DB
-	Logger *zap.Logger
+	AuthMW        *ginjwt.Middleware
+	DB            *sqlx.DB
+	Logger        *zap.Logger
+	LookupEnabled bool
+	LookupClient  lookup.Client
 }
 
 // Routes will add the routes for this API version to a router group
@@ -73,6 +84,92 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 	rg.GET(InternalUserdataWithIDURI, authMw.AuthRequired(), authMw.RequiredScopes(readScopes("userdata")), r.instanceUserdataGetInternal)
 	rg.DELETE(InternalMetadataWithIDURI, authMw.AuthRequired(), authMw.RequiredScopes(deleteScopes("metadata")), r.instanceMetadataDelete)
 	rg.DELETE(InternalUserdataWithIDURI, authMw.AuthRequired(), authMw.RequiredScopes(deleteScopes("userdata")), r.instanceUserdataDelete)
+}
+
+func (r *Router) getMetadata(c *gin.Context) (*models.InstanceMetadatum, error) {
+	instanceID := c.GetString(middleware.ContextKeyInstanceID)
+
+	if instanceID == "" {
+		// We couldn't match the request IP to an instance ID that the metadata
+		// service already knows about. So we'll try to get it from the upstream
+		// lookup service (if it's enabled and configured).
+		requestIP := c.GetString(middleware.ContextKeyRequestorIP)
+
+		if r.LookupEnabled && r.LookupClient != nil {
+			metadata, err := lookup.MetadataSyncByIP(c.Request.Context(), r.DB, r.Logger, r.LookupClient, requestIP)
+			if err != nil && errors.Is(err, lookup.ErrNotFound) {
+				return nil, errNotFound
+			}
+
+			return metadata, err
+		}
+
+		return nil, errNotFound
+	}
+
+	// We got an instance ID from the middleware, either because we could match
+	// the request IP to an ID, or the request itself provided the instance ID.
+	metadata, err := models.FindInstanceMetadatum(c.Request.Context(), r.DB, instanceID)
+
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
+		// We couldn't find an instance_metadata row for this instance ID. Try
+		// to fetch it from the upstream lookup service (if enabled and configured)
+		if r.LookupEnabled && r.LookupClient != nil {
+			metadata, err = lookup.MetadataSyncByID(c.Request.Context(), r.DB, r.Logger, r.LookupClient, instanceID)
+			if err != nil && errors.Is(err, lookup.ErrNotFound) {
+				return nil, errNotFound
+			}
+
+			return metadata, err
+		}
+
+		return nil, errNotFound
+	}
+
+	return metadata, err
+}
+
+func (r *Router) getUserdata(c *gin.Context) (*models.InstanceUserdatum, error) {
+	instanceID := c.GetString(middleware.ContextKeyInstanceID)
+
+	if instanceID == "" {
+		// We couldn't match the request IP to an instance ID that the metadata
+		// service already knows about. So we'll try to get it from the upstream
+		// lookup service (if it's enabled and configured).
+		requestIP := c.GetString(middleware.ContextKeyRequestorIP)
+
+		if r.LookupEnabled && r.LookupClient != nil {
+			userdata, err := lookup.UserdataSyncByIP(c.Request.Context(), r.DB, r.Logger, r.LookupClient, requestIP)
+			if err != nil && errors.Is(err, lookup.ErrNotFound) {
+				return nil, errNotFound
+			}
+
+			return userdata, err
+		}
+
+		return nil, errNotFound
+	}
+
+	// We got an instance ID from the middleware, either because we could match
+	// the request IP to an ID, or the request itself provided the instance ID.
+	userdata, err := models.FindInstanceUserdatum(c.Request.Context(), r.DB, instanceID)
+
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
+		// We couldn't find an instance_metadata row for this instance ID. Try
+		// to fetch it from the upstream lookup service (if enabled and configured)
+		if r.LookupEnabled && r.LookupClient != nil {
+			userdata, err = lookup.UserdataSyncByID(c.Request.Context(), r.DB, r.Logger, r.LookupClient, instanceID)
+			if err != nil && errors.Is(err, lookup.ErrNotFound) {
+				return nil, errNotFound
+			}
+
+			return userdata, err
+		}
+
+		return nil, errNotFound
+	}
+
+	return userdata, err
 }
 
 // GetMetadataPath returns the path used by an instance to fetch Metadata

--- a/pkg/api/v1/router_instance_ec2_metadata_lookup_test.go
+++ b/pkg/api/v1/router_instance_ec2_metadata_lookup_test.go
@@ -1,0 +1,130 @@
+package metadataservice_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.hollow.sh/metadataservice/internal/lookup"
+	v1api "go.hollow.sh/metadataservice/pkg/api/v1"
+)
+
+func TestGetEc2MetadataLookupByIP(t *testing.T) {
+	lookupClient := newMockLookupClient()
+	router := *testHTTPServerWithLookup(t, lookupClient)
+
+	type testCase struct {
+		testName       string
+		instanceIP     string
+		expectedStatus int
+		lookupResponse lookupResponse
+	}
+
+	validResponse := lookup.MetadataLookupResponse{
+		ID:          "81dc6612-c854-440e-87cb-ead5684c9559",
+		IPAddresses: []string{"3.4.5.6"},
+		Metadata:    `{"some":"metadata"}`,
+	}
+
+	testCases := []testCase{
+		{
+			"IPv4 address not found in lookup service",
+			"1.2.3.4",
+			http.StatusNotFound,
+			lookupResponse{
+				Error: lookup.ErrNotFound,
+			},
+		},
+		{
+			"lookup service unavailable",
+			"2.3.4.5",
+			http.StatusInternalServerError,
+			lookupResponse{
+				Error: lookup.ErrUnexpectedStatus,
+			},
+		},
+		{
+			"lookup service found instance",
+			"3.4.5.6",
+			http.StatusOK,
+			lookupResponse{
+				metadataResponse: validResponse,
+			},
+		},
+	}
+
+	for _, testcase := range testCases {
+		t.Run(testcase.testName, func(t *testing.T) {
+			lookupClient.setResponse(testcase.instanceIP, testcase.lookupResponse)
+			w := httptest.NewRecorder()
+
+			req, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, v1api.GetEc2MetadataPath(), nil)
+			req.RemoteAddr = net.JoinHostPort(testcase.instanceIP, "")
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, testcase.expectedStatus, w.Code)
+		})
+	}
+}
+
+func TestGetEc2MetadataItemLookupByIP(t *testing.T) {
+	lookupClient := newMockLookupClient()
+	router := *testHTTPServerWithLookup(t, lookupClient)
+
+	type testCase struct {
+		testName       string
+		instanceIP     string
+		expectedStatus int
+		lookupResponse lookupResponse
+	}
+
+	validResponse := lookup.MetadataLookupResponse{
+		ID:          "81dc6612-c854-440e-87cb-ead5684c9559",
+		IPAddresses: []string{"3.4.5.6"},
+		Metadata:    `{"some":"metadata","hostname":"lookup-test-hostname"}`,
+	}
+
+	testCases := []testCase{
+		{
+			"IPv4 address not found in lookup service",
+			"1.2.3.4",
+			http.StatusNotFound,
+			lookupResponse{
+				Error: lookup.ErrNotFound,
+			},
+		},
+		{
+			"lookup service unavailable",
+			"2.3.4.5",
+			http.StatusInternalServerError,
+			lookupResponse{
+				Error: lookup.ErrUnexpectedStatus,
+			},
+		},
+		{
+			"lookup service found instance",
+			"3.4.5.6",
+			http.StatusOK,
+			lookupResponse{
+				metadataResponse: validResponse,
+			},
+		},
+	}
+
+	for _, testcase := range testCases {
+		t.Run(testcase.testName, func(t *testing.T) {
+			lookupClient.setResponse(testcase.instanceIP, testcase.lookupResponse)
+			w := httptest.NewRecorder()
+
+			req, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, v1api.GetEc2MetadataItemPath("hostname"), nil)
+			req.RemoteAddr = net.JoinHostPort(testcase.instanceIP, "")
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, testcase.expectedStatus, w.Code)
+		})
+	}
+}

--- a/pkg/api/v1/router_instance_ec2_userdata_lookup_test.go
+++ b/pkg/api/v1/router_instance_ec2_userdata_lookup_test.go
@@ -1,0 +1,72 @@
+package metadataservice_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.hollow.sh/metadataservice/internal/lookup"
+	v1api "go.hollow.sh/metadataservice/pkg/api/v1"
+)
+
+func TestGetEc2UserdataLookupByIP(t *testing.T) {
+	lookupClient := newMockLookupClient()
+	router := *testHTTPServerWithLookup(t, lookupClient)
+
+	type testCase struct {
+		testName       string
+		instanceIP     string
+		expectedStatus int
+		lookupResponse lookupResponse
+	}
+
+	validResponse := lookup.UserdataLookupResponse{
+		ID:          "81dc6612-c854-440e-87cb-ead5684c9559",
+		IPAddresses: []string{"3.4.5.6"},
+		Userdata:    []byte("some userdata..."),
+	}
+
+	testCases := []testCase{
+		{
+			"IPv4 address not found in lookup service",
+			"1.2.3.4",
+			http.StatusNotFound,
+			lookupResponse{
+				Error: lookup.ErrNotFound,
+			},
+		},
+		{
+			"lookup service unavailable",
+			"2.3.4.5",
+			http.StatusInternalServerError,
+			lookupResponse{
+				Error: lookup.ErrUnexpectedStatus,
+			},
+		},
+		{
+			"lookup service found instance",
+			"3.4.5.6",
+			http.StatusOK,
+			lookupResponse{
+				userdataResponse: validResponse,
+			},
+		},
+	}
+
+	for _, testcase := range testCases {
+		t.Run(testcase.testName, func(t *testing.T) {
+			lookupClient.setResponse(testcase.instanceIP, testcase.lookupResponse)
+			w := httptest.NewRecorder()
+
+			req, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, v1api.GetEc2UserdataPath(), nil)
+			req.RemoteAddr = net.JoinHostPort(testcase.instanceIP, "")
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, testcase.expectedStatus, w.Code)
+		})
+	}
+}

--- a/pkg/api/v1/router_instance_metadata_lookup_test.go
+++ b/pkg/api/v1/router_instance_metadata_lookup_test.go
@@ -1,0 +1,72 @@
+package metadataservice_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.hollow.sh/metadataservice/internal/lookup"
+	v1api "go.hollow.sh/metadataservice/pkg/api/v1"
+)
+
+func TestGetMetadataLookupByIP(t *testing.T) {
+	lookupClient := newMockLookupClient()
+	router := *testHTTPServerWithLookup(t, lookupClient)
+
+	type testCase struct {
+		testName       string
+		instanceIP     string
+		expectedStatus int
+		lookupResponse lookupResponse
+	}
+
+	validResponse := lookup.MetadataLookupResponse{
+		ID:          "81dc6612-c854-440e-87cb-ead5684c9559",
+		IPAddresses: []string{"3.4.5.6"},
+		Metadata:    `{"some":"metadata"}`,
+	}
+
+	testCases := []testCase{
+		{
+			"IPv4 address not found in lookup service",
+			"1.2.3.4",
+			http.StatusNotFound,
+			lookupResponse{
+				Error: lookup.ErrNotFound,
+			},
+		},
+		{
+			"lookup service unavailable",
+			"2.3.4.5",
+			http.StatusInternalServerError,
+			lookupResponse{
+				Error: lookup.ErrUnexpectedStatus,
+			},
+		},
+		{
+			"lookup service found instance",
+			"3.4.5.6",
+			http.StatusOK,
+			lookupResponse{
+				metadataResponse: validResponse,
+			},
+		},
+	}
+
+	for _, testcase := range testCases {
+		t.Run(testcase.testName, func(t *testing.T) {
+			lookupClient.setResponse(testcase.instanceIP, testcase.lookupResponse)
+			w := httptest.NewRecorder()
+
+			req, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, v1api.GetMetadataPath(), nil)
+			req.RemoteAddr = net.JoinHostPort(testcase.instanceIP, "")
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, testcase.expectedStatus, w.Code)
+		})
+	}
+}

--- a/pkg/api/v1/router_instance_userdata_lookup_test.go
+++ b/pkg/api/v1/router_instance_userdata_lookup_test.go
@@ -1,0 +1,72 @@
+package metadataservice_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.hollow.sh/metadataservice/internal/lookup"
+	v1api "go.hollow.sh/metadataservice/pkg/api/v1"
+)
+
+func TestGetUserdataLookupByIP(t *testing.T) {
+	lookupClient := newMockLookupClient()
+	router := *testHTTPServerWithLookup(t, lookupClient)
+
+	type testCase struct {
+		testName       string
+		instanceIP     string
+		expectedStatus int
+		lookupResponse lookupResponse
+	}
+
+	validResponse := lookup.UserdataLookupResponse{
+		ID:          "81dc6612-c854-440e-87cb-ead5684c9559",
+		IPAddresses: []string{"3.4.5.6"},
+		Userdata:    []byte("some userdata..."),
+	}
+
+	testCases := []testCase{
+		{
+			"IPv4 address not found in lookup service",
+			"1.2.3.4",
+			http.StatusNotFound,
+			lookupResponse{
+				Error: lookup.ErrNotFound,
+			},
+		},
+		{
+			"lookup service unavailable",
+			"2.3.4.5",
+			http.StatusInternalServerError,
+			lookupResponse{
+				Error: lookup.ErrUnexpectedStatus,
+			},
+		},
+		{
+			"lookup service found instance",
+			"3.4.5.6",
+			http.StatusOK,
+			lookupResponse{
+				userdataResponse: validResponse,
+			},
+		},
+	}
+
+	for _, testcase := range testCases {
+		t.Run(testcase.testName, func(t *testing.T) {
+			lookupClient.setResponse(testcase.instanceIP, testcase.lookupResponse)
+			w := httptest.NewRecorder()
+
+			req, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, v1api.GetUserdataPath(), nil)
+			req.RemoteAddr = net.JoinHostPort(testcase.instanceIP, "")
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, testcase.expectedStatus, w.Code)
+		})
+	}
+}

--- a/pkg/api/v1/router_test.go
+++ b/pkg/api/v1/router_test.go
@@ -1,6 +1,7 @@
 package metadataservice_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 
 	"go.hollow.sh/metadataservice/internal/dbtools"
 	"go.hollow.sh/metadataservice/internal/httpsrv"
+	"go.hollow.sh/metadataservice/internal/lookup"
 )
 
 func testHTTPServer(t *testing.T) *http.Handler {
@@ -21,4 +23,68 @@ func testHTTPServer(t *testing.T) *http.Handler {
 	s := hs.NewServer()
 
 	return &s.Handler
+}
+
+func testHTTPServerWithLookup(t *testing.T, lookupClient lookup.Client) *http.Handler {
+	authConfig := ginjwt.AuthConfig{}
+
+	db := dbtools.DatabaseTest(t)
+
+	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfig: authConfig, DB: db, LookupEnabled: true, LookupClient: lookupClient}
+
+	s := hs.NewServer()
+
+	return &s.Handler
+}
+
+type lookupResponse struct {
+	metadataResponse lookup.MetadataLookupResponse
+	userdataResponse lookup.UserdataLookupResponse
+	Error            error
+}
+
+type mockLookupClient struct {
+	responses map[string]lookupResponse
+}
+
+func newMockLookupClient() *mockLookupClient {
+	return &mockLookupClient{responses: make(map[string]lookupResponse)}
+}
+
+func (m *mockLookupClient) setResponse(key string, resp lookupResponse) {
+	m.responses[key] = resp
+}
+
+func (m *mockLookupClient) getMetadataResponse(key string) (*lookup.MetadataLookupResponse, error) {
+	resp, exists := m.responses[key]
+	if !exists {
+		return nil, lookup.ErrNotFound
+	}
+
+	return &resp.metadataResponse, resp.Error
+}
+
+func (m *mockLookupClient) getUserdataResponse(key string) (*lookup.UserdataLookupResponse, error) {
+	resp, exists := m.responses[key]
+	if !exists {
+		return nil, lookup.ErrNotFound
+	}
+
+	return &resp.userdataResponse, resp.Error
+}
+
+func (m *mockLookupClient) GetMetadataByID(_ context.Context, id string) (*lookup.MetadataLookupResponse, error) {
+	return m.getMetadataResponse(id)
+}
+
+func (m *mockLookupClient) GetMetadataByIP(_ context.Context, ip string) (*lookup.MetadataLookupResponse, error) {
+	return m.getMetadataResponse(ip)
+}
+
+func (m *mockLookupClient) GetUserdataByID(_ context.Context, id string) (*lookup.UserdataLookupResponse, error) {
+	return m.getUserdataResponse(id)
+}
+
+func (m *mockLookupClient) GetUserdataByIP(_ context.Context, ip string) (*lookup.UserdataLookupResponse, error) {
+	return m.getUserdataResponse(ip)
 }


### PR DESCRIPTION
- Adds a client for calling out to an upstream HTTP "lookup" service, used when an instance requests its metadata or userdata, but the metadata service does not have anything recorded for the instance.
    - This will attempt to locate metadata or userdata for the requesting instance from an upstream source, and if found, it will record that metadata/userdata in the metadata service itself so future requests don't require the same round-trip set of calls.
- Refactor the "upsert" logic used when inserting/updating metadata and userdata -- pulled out of the endpoint handler itself and into a separate package so it can be more easily shared between the endpoint and the lookup service client.