### PR TITLE
Add support for templated fields in metadata response

### DIFF
--- a/internal/httpsrv/server.go
+++ b/internal/httpsrv/server.go
@@ -3,6 +3,7 @@ package httpsrv
 import (
 	"net/http"
 	"os"
+	"text/template"
 	"time"
 
 	"github.com/gin-contrib/cors"
@@ -30,6 +31,7 @@ type Server struct {
 	TrustedProxies []string
 	LookupEnabled  bool
 	LookupClient   lookup.Client
+	TemplateFields map[string]template.Template
 }
 
 var (
@@ -104,7 +106,7 @@ func (s *Server) setup() *gin.Engine {
 	r.GET("/healthz/liveness", s.livenessCheck)
 	r.GET("/healthz/readiness", s.readinessCheck)
 
-	v1Rtr := v1api.Router{AuthMW: authMW, DB: s.DB, Logger: s.Logger, LookupEnabled: s.LookupEnabled, LookupClient: s.LookupClient}
+	v1Rtr := v1api.Router{AuthMW: authMW, DB: s.DB, Logger: s.Logger, LookupEnabled: s.LookupEnabled, LookupClient: s.LookupClient, TemplateFields: s.TemplateFields}
 
 	// Host our latest version of the API under / in addition to /api/v*
 	latest := r.Group("/")

--- a/pkg/api/v1/router.go
+++ b/pkg/api/v1/router.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"reflect"
 	"strings"
+	"text/template"
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
@@ -62,11 +63,12 @@ var (
 
 // Router provides a router for the v1 API
 type Router struct {
-	AuthMW        *ginjwt.Middleware
-	DB            *sqlx.DB
-	Logger        *zap.Logger
-	LookupEnabled bool
-	LookupClient  lookup.Client
+	AuthMW         *ginjwt.Middleware
+	DB             *sqlx.DB
+	Logger         *zap.Logger
+	LookupEnabled  bool
+	LookupClient   lookup.Client
+	TemplateFields map[string]template.Template
 }
 
 // Routes will add the routes for this API version to a router group

--- a/pkg/api/v1/router_instance_ec2_metadata_lookup_test.go
+++ b/pkg/api/v1/router_instance_ec2_metadata_lookup_test.go
@@ -15,7 +15,8 @@ import (
 
 func TestGetEc2MetadataLookupByIP(t *testing.T) {
 	lookupClient := newMockLookupClient()
-	router := *testHTTPServerWithLookup(t, lookupClient)
+	serverConfig := TestServerConfig{LookupEnabled: true, LookupClient: lookupClient}
+	router := *testHTTPServerWithConfig(t, serverConfig)
 
 	type testCase struct {
 		testName       string
@@ -73,7 +74,8 @@ func TestGetEc2MetadataLookupByIP(t *testing.T) {
 
 func TestGetEc2MetadataItemLookupByIP(t *testing.T) {
 	lookupClient := newMockLookupClient()
-	router := *testHTTPServerWithLookup(t, lookupClient)
+	serverConfig := TestServerConfig{LookupEnabled: true, LookupClient: lookupClient}
+	router := *testHTTPServerWithConfig(t, serverConfig)
 
 	type testCase struct {
 		testName       string

--- a/pkg/api/v1/router_instance_ec2_userdata_lookup_test.go
+++ b/pkg/api/v1/router_instance_ec2_userdata_lookup_test.go
@@ -15,7 +15,8 @@ import (
 
 func TestGetEc2UserdataLookupByIP(t *testing.T) {
 	lookupClient := newMockLookupClient()
-	router := *testHTTPServerWithLookup(t, lookupClient)
+	serverConfig := TestServerConfig{LookupEnabled: true, LookupClient: lookupClient}
+	router := *testHTTPServerWithConfig(t, serverConfig)
 
 	type testCase struct {
 		testName       string

--- a/pkg/api/v1/router_instance_metadata.go
+++ b/pkg/api/v1/router_instance_metadata.go
@@ -65,7 +65,12 @@ func (r *Router) instanceMetadataGet(c *gin.Context) {
 	}
 
 	if metadata != nil {
-		c.JSON(http.StatusOK, metadata.Metadata)
+		augmentedMetadata, err := addTemplateFields(metadata.Metadata, r.TemplateFields)
+		if err != nil {
+			r.Logger.Sugar().Warnf("Error adding additional templated fields to metadata for instance %s", metadata.ID, "error", err)
+		}
+
+		c.JSON(http.StatusOK, augmentedMetadata)
 	} else {
 		notFoundResponse(c)
 	}
@@ -95,7 +100,12 @@ func (r *Router) instanceMetadataGetInternal(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, metadata.Metadata)
+	augmentedMetadata, err := addTemplateFields(metadata.Metadata, r.TemplateFields)
+	if err != nil {
+		r.Logger.Sugar().Warnf("Error adding additional templated fields to metadata for instance %s", metadata.ID, "error", err)
+	}
+
+	c.JSON(http.StatusOK, augmentedMetadata)
 }
 
 func (r *Router) instanceUserdataGet(c *gin.Context) {

--- a/pkg/api/v1/router_instance_metadata.go
+++ b/pkg/api/v1/router_instance_metadata.go
@@ -68,9 +68,12 @@ func (r *Router) instanceMetadataGet(c *gin.Context) {
 		augmentedMetadata, err := addTemplateFields(metadata.Metadata, r.TemplateFields)
 		if err != nil {
 			r.Logger.Sugar().Warnf("Error adding additional templated fields to metadata for instance %s", metadata.ID, "error", err)
-		}
 
-		c.JSON(http.StatusOK, augmentedMetadata)
+			// Since we couldn't add the templated fields, just return the metadata as-is
+			c.JSON(http.StatusOK, metadata.Metadata)
+		} else {
+			c.JSON(http.StatusOK, augmentedMetadata)
+		}
 	} else {
 		notFoundResponse(c)
 	}
@@ -103,9 +106,12 @@ func (r *Router) instanceMetadataGetInternal(c *gin.Context) {
 	augmentedMetadata, err := addTemplateFields(metadata.Metadata, r.TemplateFields)
 	if err != nil {
 		r.Logger.Sugar().Warnf("Error adding additional templated fields to metadata for instance %s", metadata.ID, "error", err)
-	}
 
-	c.JSON(http.StatusOK, augmentedMetadata)
+		// Since we couldn't add the templated fields, just return the metadata as-is
+		c.JSON(http.StatusOK, metadata.Metadata)
+	} else {
+		c.JSON(http.StatusOK, augmentedMetadata)
+	}
 }
 
 func (r *Router) instanceUserdataGet(c *gin.Context) {

--- a/pkg/api/v1/router_instance_metadata_lookup_test.go
+++ b/pkg/api/v1/router_instance_metadata_lookup_test.go
@@ -15,7 +15,8 @@ import (
 
 func TestGetMetadataLookupByIP(t *testing.T) {
 	lookupClient := newMockLookupClient()
-	router := *testHTTPServerWithLookup(t, lookupClient)
+	serverConfig := TestServerConfig{LookupEnabled: true, LookupClient: lookupClient}
+	router := *testHTTPServerWithConfig(t, serverConfig)
 
 	type testCase struct {
 		testName       string

--- a/pkg/api/v1/router_instance_metadata_test.go
+++ b/pkg/api/v1/router_instance_metadata_test.go
@@ -137,12 +137,19 @@ func TestGetMetadataByIPWithTemplateFields(t *testing.T) {
 		t.Error(err)
 	}
 
+	// Test that a field can just be static text
+	staticTextTmpl, err := template.New("staticText").Parse("just some static text")
+	if err != nil {
+		t.Error(err)
+	}
+
 	config := TestServerConfig{
 		TemplateFields: map[string]template.Template{
 			"phone_home_url": *phoneHomeTmpl,
 			"user_state_url": *userStateTmpl,
 			"missing_field":  *missingFieldTmpl,
 			"hostname":       *existingFieldTmpl,
+			"static_text":    *staticTextTmpl,
 		},
 	}
 
@@ -168,6 +175,7 @@ func TestGetMetadataByIPWithTemplateFields(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("https://da.user.state/events/%s", dbtools.FixtureInstanceA.InstanceID), resultMap["user_state_url"])
 	assert.Equal(t, "instance-a", resultMap["hostname"])
 	assert.Nil(t, resultMap["missingField"])
+	assert.Equal(t, "just some static text", resultMap["static_text"])
 }
 
 // TestSetMetadataRequestValidations tests the different validations performed

--- a/pkg/api/v1/router_instance_userdata_lookup_test.go
+++ b/pkg/api/v1/router_instance_userdata_lookup_test.go
@@ -15,7 +15,8 @@ import (
 
 func TestGetUserdataLookupByIP(t *testing.T) {
 	lookupClient := newMockLookupClient()
-	router := *testHTTPServerWithLookup(t, lookupClient)
+	serverConfig := TestServerConfig{LookupEnabled: true, LookupClient: lookupClient}
+	router := *testHTTPServerWithConfig(t, serverConfig)
 
 	type testCase struct {
 		testName       string

--- a/pkg/api/v1/router_test.go
+++ b/pkg/api/v1/router_test.go
@@ -13,6 +13,11 @@ import (
 	"go.hollow.sh/metadataservice/internal/lookup"
 )
 
+type TestServerConfig struct {
+	LookupEnabled bool
+	LookupClient  lookup.Client
+}
+
 func testHTTPServer(t *testing.T) *http.Handler {
 	authConfig := ginjwt.AuthConfig{}
 
@@ -25,12 +30,14 @@ func testHTTPServer(t *testing.T) *http.Handler {
 	return &s.Handler
 }
 
-func testHTTPServerWithLookup(t *testing.T, lookupClient lookup.Client) *http.Handler {
+func testHTTPServerWithConfig(t *testing.T, config TestServerConfig) *http.Handler {
 	authConfig := ginjwt.AuthConfig{}
-
 	db := dbtools.DatabaseTest(t)
 
-	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfig: authConfig, DB: db, LookupEnabled: true, LookupClient: lookupClient}
+	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfig: authConfig, DB: db}
+
+	hs.LookupEnabled = config.LookupEnabled
+	hs.LookupClient = config.LookupClient
 
 	s := hs.NewServer()
 

--- a/pkg/api/v1/router_test.go
+++ b/pkg/api/v1/router_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"text/template"
 
 	"go.hollow.sh/toolbox/ginjwt"
 	"go.uber.org/zap"
@@ -14,8 +15,9 @@ import (
 )
 
 type TestServerConfig struct {
-	LookupEnabled bool
-	LookupClient  lookup.Client
+	LookupEnabled  bool
+	LookupClient   lookup.Client
+	TemplateFields map[string]template.Template
 }
 
 func testHTTPServer(t *testing.T) *http.Handler {
@@ -38,6 +40,7 @@ func testHTTPServerWithConfig(t *testing.T, config TestServerConfig) *http.Handl
 
 	hs.LookupEnabled = config.LookupEnabled
 	hs.LookupClient = config.LookupClient
+	hs.TemplateFields = config.TemplateFields
 
 	s := hs.NewServer()
 


### PR DESCRIPTION
This PR adds support for augmenting metadata responses with a `phone_home_url` and a `user_state_url`. Because these fields can be dynamic, we'll support templating these field results using normal golang `text/template` template strings.

Also did a small refactor on how we set up the http server/router in tests, allowing us to pass in a struct to set the different config options for the router in each test.