### PR TITLE
Add Chainguard Enforce configuration

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -1,0 +1,10 @@
+---
+spec:
+  authorities:
+    # Accept all keyless signatures validated from the public sigstore instance.
+    # This is open source software after all. All we want to know is that the
+    # person that did the commit has control over their email address.
+    - keyless: {}
+    # Add this if you also want to allow commits signed by GitHub.
+    - key:
+        kms: https://github.com/web-flow.gpg


### PR DESCRIPTION
This is meant to configure the Chainguard Enforce GitHub app which will
enforce sigstore-powered commit signatures. To enable it, install
gitsign [1] and enable it for this repo:

```bash
cd /path/to/this/repository
git config --local commit.gpgsign true  # Sign all commits
git config --local tag.gpgsign true  # Sign all tags
git config --local gpg.x509.program gitsign  # Use gitsign for signing
git config --local gpg.format x509  # gitsign expects x509 args
```

Note that this won't be enforcing as of yet. I'll do that separately.
This is just the configuration.

[1] https://github.com/sigstore/gitsign

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
