### PR TITLE
Add prometheus metrics for various request operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/lib/pq v1.10.7
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.13.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.14.0
@@ -39,7 +40,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ericlagergren/decimal v0.0.0-20181231230500-73749d4874d5 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/gin-contrib/requestid v0.0.6 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -48,7 +48,6 @@ require (
 	github.com/goccy/go-json v0.9.11 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
@@ -72,7 +71,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pressly/goose/v3 v3.7.0 // indirect
-	github.com/prometheus/client_golang v1.13.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,6 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
-github.com/cockroachdb/cockroach-go/v2 v2.2.16 h1:t9dmZuC9J2W8IDQDSIGXmP+fBuEJSsrGXxWQz4cYqBY=
-github.com/cockroachdb/cockroach-go/v2 v2.2.16/go.mod h1:xZ2VHjUEb/cySv0scXBx7YsBnHtLHkR1+w/w73b5i3M=
 github.com/cockroachdb/cockroach-go/v2 v2.2.17 h1:Yjmt2MpXXjw5yYY+SWbrbVJ7wpZzhMQfO0XbDUeELb0=
 github.com/cockroachdb/cockroach-go/v2 v2.2.17/go.mod h1:mzlIDDBALQfEjv/7DU12fb2AfQ/MUYTlychcMpWp9QI=
 github.com/coreos/go-oidc/v3 v3.4.0 h1:xz7elHb/LDwm/ERpwHd+5nb7wFHL32rsr6bBOgaeu6g=
@@ -159,8 +157,6 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/cors v1.4.0 h1:oJ6gwtUl3lqV0WEIwM/LxPF1QZ5qe2lGWdY2+bz7y0g=
 github.com/gin-contrib/cors v1.4.0/go.mod h1:bs9pNM0x/UsmHPBWT2xZz9ROh8xYjYkiURUfmBoMlcs=
-github.com/gin-contrib/requestid v0.0.6 h1:mGcxTnHQ45F6QU5HQRgQUDsAfHprD3P7g2uZ4cSZo9o=
-github.com/gin-contrib/requestid v0.0.6/go.mod h1:9i4vKATX/CdggbkY252dPVasgVucy/ggBeELXuQztm4=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
@@ -587,8 +583,6 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/spf13/viper v1.9.0/go.mod h1:+i6ajR7OX2XaiBkrcZJFK21htRk7eDeLg7+O6bhUPP4=
-github.com/spf13/viper v1.13.0 h1:BWSJ/M+f+3nmdz9bxB+bWX28kkALN2ok11D0rSo8EJU=
-github.com/spf13/viper v1.13.0/go.mod h1:Icm2xNL3/8uyh/wFuB1jI7TiTNKp8632Nwegu+zgdYw=
 github.com/spf13/viper v1.14.0 h1:Rg7d3Lo706X9tHsJMUjdiwMpHB7W8WnSVOssIY+JElU=
 github.com/spf13/viper v1.14.0/go.mod h1:WT//axPky3FdvXHzGw33dNdXXXfFQqmEalje+egj8As=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -814,8 +808,6 @@ golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
-golang.org/x/net v0.1.0 h1:hZ/3BUoy5aId7sCpA/Tc5lt8DkFgdVS2onTpJsZ/fl0=
-golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.2.0 h1:sZfSu1wtKLGlWI4ZZayP0ck9Y73K1ynO6gqzTdBVdPU=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -840,8 +832,6 @@ golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb/go.mod h1:jaDAt6Dkxork7LmZnYtzbRWj0W47D86a3TGe0YHBvmE=
 golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
-golang.org/x/oauth2 v0.1.0 h1:isLCZuhj4v+tYv7eskaN4v/TM+A1begWWgyVJDdl1+Y=
-golang.org/x/oauth2 v0.1.0/go.mod h1:G9FE4dLTsbXUu90h/Pf85g4w1D+SSAgR+q46nJZ8M4A=
 golang.org/x/oauth2 v0.2.0 h1:GtQkldQ9m7yvzCL1V+LrYow3Khe0eJH0w7RbX/VbaIU=
 golang.org/x/oauth2 v0.2.0/go.mod h1:Cwn6afJ8jrQwYMxQDTpISoXmXW9I6qF6vDeuuoX3Ibs=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -949,8 +939,6 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
-golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -1042,7 +1030,6 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
-golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f h1:uF6paiQQebLeSXkrTqHqz0MXhXXS1KgF41eUdBNvxK0=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
@@ -1173,7 +1160,6 @@ google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3/go.mod h1:RAyBrSAP
 google.golang.org/genproto v0.0.0-20220518221133-4f43b3371335/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220523171625-347a074981d8/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
-google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90 h1:4SPz2GL2CXJt28MTF8V6Ap/9ZiVbQlJeGSd9qtA7DLs=
 google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20221024183307-1bc688fe9f3e h1:S9GbmC1iCgvbLyAokVCwiO6tVIrU9Y7c5oMx1V/ki/Y=
 google.golang.org/genproto v0.0.0-20221024183307-1bc688fe9f3e/go.mod h1:9qHF0xnpdSfF6knlcsnpzUu5y+rpwgbvsyGAZPBMg4s=

--- a/internal/lookup/lookup.go
+++ b/internal/lookup/lookup.go
@@ -9,6 +9,7 @@ import (
 	"github.com/volatiletech/sqlboiler/v4/types"
 	"go.uber.org/zap"
 
+	"go.hollow.sh/metadataservice/internal/middleware"
 	"go.hollow.sh/metadataservice/internal/models"
 	"go.hollow.sh/metadataservice/internal/upserter"
 )
@@ -37,8 +38,11 @@ func MetadataSyncByID(ctx context.Context, db *sqlx.DB, logger *zap.Logger, clie
 		return nil, errNilClient
 	}
 
+	middleware.MetricMetadataLookupRequestCount.Inc()
+
 	resp, err := client.GetMetadataByID(ctx, id)
 	if err != nil {
+		middleware.MetricLookupErrors.Inc()
 		return nil, err
 	}
 
@@ -54,8 +58,11 @@ func MetadataSyncByIP(ctx context.Context, db *sqlx.DB, logger *zap.Logger, clie
 		return nil, errNilClient
 	}
 
+	middleware.MetricMetadataLookupRequestCount.Inc()
+
 	resp, err := client.GetMetadataByIP(ctx, ipAddress)
 	if err != nil {
+		middleware.MetricLookupErrors.Inc()
 		return nil, err
 	}
 
@@ -71,8 +78,11 @@ func UserdataSyncByID(ctx context.Context, db *sqlx.DB, logger *zap.Logger, clie
 		return nil, errNilClient
 	}
 
+	middleware.MetricUserdataLookupRequestCount.Inc()
+
 	resp, err := client.GetUserdataByID(ctx, id)
 	if err != nil {
+		middleware.MetricUserdataLookupErrors.Inc()
 		return nil, err
 	}
 
@@ -88,8 +98,11 @@ func UserdataSyncByIP(ctx context.Context, db *sqlx.DB, logger *zap.Logger, clie
 		return nil, errNilClient
 	}
 
+	middleware.MetricUserdataLookupRequestCount.Inc()
+
 	resp, err := client.GetUserdataByID(ctx, ipAddress)
 	if err != nil {
+		middleware.MetricUserdataLookupErrors.Inc()
 		return nil, err
 	}
 
@@ -104,8 +117,11 @@ func storeMetadata(ctx context.Context, db *sqlx.DB, logger *zap.Logger, lookupR
 
 	err := upserter.UpsertMetadata(ctx, db, logger, lookupResp.ID, lookupResp.IPAddresses, newInstanceMetadata)
 	if err != nil {
+		middleware.MetricMetadataStoreErrors.Inc()
 		return nil, err
 	}
+
+	middleware.MetricMetadataInsertsCount.Inc()
 
 	return newInstanceMetadata, nil
 }
@@ -118,8 +134,11 @@ func storeUserdata(ctx context.Context, db *sqlx.DB, logger *zap.Logger, lookupR
 
 	err := upserter.UpsertUserdata(ctx, db, logger, lookupResp.ID, lookupResp.IPAddresses, newInstanceUserdata)
 	if err != nil {
+		middleware.MetricUserdataStoreErrors.Inc()
 		return nil, err
 	}
+
+	middleware.MetricUserdataInsertsCount.Inc()
 
 	return newInstanceUserdata, nil
 }

--- a/internal/middleware/metrics.go
+++ b/internal/middleware/metrics.go
@@ -1,0 +1,86 @@
+package middleware
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// MetricMetadataCacheHit total number of metadata requests not requiring external lookups
+	MetricMetadataCacheHit = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "metadata_cache_hit_total",
+		Help: "Number of metadata requests that were immediately found in the db.",
+	})
+
+	// MetricMetadataCacheMiss total number of metadata requests that required external lookups
+	MetricMetadataCacheMiss = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "metadata_cache_miss_total",
+		Help: "Number of metadata requests not found in the db that needed to be sent to the lookup service.",
+	})
+
+	// MetricUserdataCacheHit total number of userdata requests not requiring external lookups
+	MetricUserdataCacheHit = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "metadata_userdata_cache_hit_total",
+		Help: "Number of userdata requests that were immediately found in the db.",
+	})
+
+	// MetricUserdataCacheMiss total number of requests that required external lookups
+	MetricUserdataCacheMiss = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "metadata_userdata_cache_miss_total",
+		Help: "Number of userdata requests not found in the db that needed to be sent to the lookup service.",
+	})
+
+	// MetricMetadataLookupRequestCount total number of metadata requests sent to the external lookup service
+	MetricMetadataLookupRequestCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "metadata_lookup_request_total",
+		Help: "Number of metadata lookup requests.",
+	})
+
+	// MetricUserdataLookupRequestCount total number of userdata requests sent to the external lookup service
+	MetricUserdataLookupRequestCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "metadata_userdata_lookup_request_total",
+		Help: "Number of userdata lookup requests.",
+	})
+
+	// MetricMetadataInsertsCount total number of metadata inserts (which originate from the API)
+	MetricMetadataInsertsCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "metadata_inserts_total",
+		Help: "Number of metadata inserts (which originate from the API).",
+	})
+
+	// MetricUserdataInsertsCount total number of userdata inserts (which originate from the API)
+	MetricUserdataInsertsCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "metadata_userdata_inserts_total",
+		Help: "Number of userdata inserts (which originate from the API).",
+	})
+
+	// MetricDeletionsCount total number of metadata deletions (which originate from the API)
+	MetricDeletionsCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "metadata_deletions_total",
+		Help: "Number of metadata deletions (which originate from the API).",
+	})
+
+	// MetricLookupErrors total number of errors produced during external lookup requests
+	MetricLookupErrors = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "metadata_lookup_error_total",
+		Help: "Number of errors produced during metadata lookups.",
+	})
+
+	// MetricMetadataStoreErrors total number of errors produced during saving/updating metadata to the db
+	MetricMetadataStoreErrors = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "metadata_store_error_total",
+		Help: "Number of errors produced while saving or updating metadata to the database.",
+	})
+
+	// MetricUserdataLookupErrors total number of errors produced during external userdata lookup requests
+	MetricUserdataLookupErrors = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "metadata_userdata_lookup_error_total",
+		Help: "Number of errors produced during metadata lookups.",
+	})
+
+	// MetricUserdataStoreErrors total number of errors produced during saving/updating userdata to the db
+	MetricUserdataStoreErrors = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "metadata_userdata_store_error_total",
+		Help: "Number of errors produced while saving or updating userdata to the database.",
+	})
+)

--- a/pkg/api/v1/router_instance_metadata.go
+++ b/pkg/api/v1/router_instance_metadata.go
@@ -9,6 +9,7 @@ import (
 	"github.com/volatiletech/null/v8"
 	"github.com/volatiletech/sqlboiler/v4/types"
 
+	"go.hollow.sh/metadataservice/internal/middleware"
 	"go.hollow.sh/metadataservice/internal/models"
 	"go.hollow.sh/metadataservice/internal/upserter"
 )
@@ -384,6 +385,8 @@ func handleDeleteRequest(c *gin.Context, r *Router, instanceID string, metadata 
 
 		return
 	}
+
+	middleware.MetricDeletionsCount.Inc()
 
 	c.Status(http.StatusOK)
 }


### PR DESCRIPTION
This enables tracking stats for:

* Requests we were able to handle locally (cache hits)
* Requests not found locally (cache misses)
* Requests that went to the lookup service (not necessarily the same as cache misses, this additionally requires the lookup client to be valid)
* Insert requests (which originate from the API/MLU)
* Deletion operations (which originate from the API/MLU)
* Errors produced during lookups
* Errors produced during storing of metadata to the db

Additionally, all userdata-specific operations have been separated out to their own metrics.