### PR TITLE
Handle queries where the EC2 subPath is empty

### DIFF
--- a/pkg/api/v1/router_instance_ec2_metadata.go
+++ b/pkg/api/v1/router_instance_ec2_metadata.go
@@ -91,6 +91,13 @@ func (r *Router) instanceEc2MetadataItemGet(c *gin.Context) {
 	}
 
 	if subPath, ok := c.Params.Get("subpath"); ok {
+		// If subPath is empty, we're just hitting the EC2 endpoint with a trailing
+		// slash, so perform the same operation as in instanceEc2MetadataGet()
+		if subPath == "" {
+			c.String(http.StatusOK, strings.Join(metadata.ItemNames(), "\n"))
+			return
+		}
+
 		if result, ok := metadata.GetItem(subPath); ok {
 			c.String(http.StatusOK, strings.Join(result, "\n"))
 			return


### PR DESCRIPTION
We were reporting 404 errors when hitting the address

https://metadata.equinixmetal.net/2009-04-04/meta-data/

The trailing slash was routing us to a method that assumed subPath had an endpoint in it. So account for an empty subPath by returning metadata.ItemNames() as we would if the trailing slash was not included in the request.