### PR TITLE
Handle queries where the EC2 subPath is "/", and misc fixes

### DIFF
--- a/.github/workflows/container-scan-trivy.yml
+++ b/.github/workflows/container-scan-trivy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.20'
 
       - name: Build go binary
         run: |

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -29,7 +29,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: '1.20'
       -
         name: install cosign
         uses: sigstore/cosign-installer@main

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.20'
 
       - name: Install cockroach binary
         run: curl https://binaries.cockroachdb.com/cockroach-v21.1.7.linux-amd64.tgz | tar -xz && sudo cp -i cockroach-v21.1.7.linux-amd64/cockroach /usr/local/bin/
@@ -33,7 +33,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.51.1
           args: --timeout=5m
 
       - name: Run go tests for generated models code

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 
 # Create and change to the app directory.
 WORKDIR /app
@@ -11,7 +11,7 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . ./
 
-RUN go mod tidy -go=1.18
+RUN go mod tidy -go=1.20
 
 # Build the binary.
 # -mod=readonly ensures immutable go.mod and go.sum in container builds.

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ clean: docker-clean
 
 vendor:
 	@go mod download
-	@go mod tidy -go=1.19
+	@go mod tidy -go=1.20
 
 docker-up:
 	@docker-compose -f quickstart.yml up -d crdb

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.hollow.sh/metadataservice
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cockroachdb/cockroach-go/v2 v2.2.17

--- a/pkg/api/v1/router_instance_ec2_metadata.go
+++ b/pkg/api/v1/router_instance_ec2_metadata.go
@@ -91,9 +91,10 @@ func (r *Router) instanceEc2MetadataItemGet(c *gin.Context) {
 	}
 
 	if subPath, ok := c.Params.Get("subpath"); ok {
-		// If subPath is empty, we're just hitting the EC2 endpoint with a trailing
-		// slash, so perform the same operation as in instanceEc2MetadataGet()
-		if subPath == "" {
+		// If subPath is only a fwd slash, we're just hitting the EC2 endpoint
+		// with a trailing slash, so return the ItemNames as we would in
+		// instanceEc2MetadataGet()
+		if subPath == "/" {
 			c.String(http.StatusOK, strings.Join(metadata.ItemNames(), "\n"))
 			return
 		}

--- a/quickstart.yml
+++ b/quickstart.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   metadataservice:
-    image: ghcr.io/metal-toolbox/hollow-metadaaservice:v0.0.1
+    image: ghcr.io/metal-toolbox/hollow-metadaaservice:v0.0.8
     depends_on:
       crdb:
         condition: service_healthy
@@ -18,7 +18,7 @@ services:
       - metadataservice
 
   metadataservice-migrate:
-    image: ghcr.io/metal-toolbox/hollow-metadataservice:v0.0.1
+    image: ghcr.io/metal-toolbox/hollow-metadataservice:v0.0.8
     command:
       migrate up
     depends_on:


### PR DESCRIPTION
We were reporting 404 errors when hitting the address

https://metadata.equinixmetal.net/2009-04-04/meta-data/

The trailing slash was routing us to a method that assumed subPath had
an endpoint in it. So account for an empty subPath by returning
metadata.ItemNames() as we would if the trailing slash was not included
in the request.

Update app and CI to use golang 1.20, misc cleanups.