### PR TITLE
goreleaser fixes

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -33,6 +33,8 @@ jobs:
       -
         name: install cosign
         uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.13.1'
       -
         uses: anchore/sbom-action/download-syft@v0.13.1
       -
@@ -40,7 +42,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_EXPERIMENTAL: 1


### PR DESCRIPTION
This pins cosign-release to v1.13.1 and fixes a deprecation in the goreleaser args.

cosign recently introduced some breaking changes and wants manual confirmation before it will release based on a tag. This gives us time to think about whether/how we want to change our workflow for releases.