### PR TITLE
Add retries for db commit operations in upsert and delete

### DIFF
--- a/internal/upserter/upserter.go
+++ b/internal/upserter/upserter.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.hollow.sh/metadataservice/internal/models"
+	util "go.hollow.sh/metadataservice/utils"
 )
 
 // RecordUpserter is a function defined in by each metadata or userdata upsert
@@ -178,7 +179,8 @@ func doUpsert(ctx context.Context, db *sqlx.DB, logger *zap.Logger, id string, i
 
 	// Step 8
 	// Commit our transaction
-	if err := tx.Commit(); err != nil {
+	maxRetries := 5
+	if err := util.RetryDBCommit(tx, maxRetries, logger); err != nil {
 		txErr = true
 
 		return err

--- a/pkg/api/v1/router_instance_metadata.go
+++ b/pkg/api/v1/router_instance_metadata.go
@@ -14,6 +14,7 @@ import (
 	"go.hollow.sh/metadataservice/internal/middleware"
 	"go.hollow.sh/metadataservice/internal/models"
 	"go.hollow.sh/metadataservice/internal/upserter"
+	util "go.hollow.sh/metadataservice/utils"
 )
 
 // UpsertMetadataRequest contains the fields for inserting or updating an
@@ -442,7 +443,8 @@ func handleDeleteRequest(c *gin.Context, r *Router, instanceID string, metadata 
 
 	// Step 5
 	// commit our transaction
-	if err := tx.Commit(); err != nil {
+	maxRetries := 5
+	if err := util.RetryDBCommit(tx, maxRetries, r.Logger); err != nil {
 		txErr = true
 
 		dbErrorResponse(r.Logger, c, err)

--- a/utils/util.go
+++ b/utils/util.go
@@ -1,0 +1,37 @@
+// Package util includes common, shared functions
+package util
+
+import (
+	"database/sql"
+	"math/rand"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// RetryDBCommitMaxSleep - max sleep time during DB commit retries, in seconds
+const RetryDBCommitMaxSleep = 3
+
+// RetryDBCommit commits a db transaction, using up to maxRetries retries if necessary
+func RetryDBCommit(tx *sql.Tx, maxRetries int, logger *zap.Logger) error {
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		err = tx.Commit()
+		if err == nil {
+			return nil
+		}
+
+		logger.Sugar().Warnw("Unable to commit database transaction",
+			"attempt #", i,
+			"max_attempts", maxRetries,
+			"error", err,
+		)
+
+		// Exponential backoff would be overkill here, but adding a bit of jitter
+		// to sleep a short time is reasonable
+		jitter := time.Duration(rand.Int63n(int64(RetryDBCommitMaxSleep * time.Second)))
+		time.Sleep(jitter)
+	}
+
+	return err
+}


### PR DESCRIPTION
According to CRDB's documentation, batched sql statements within a transaction can sometimes require retry logic in the client code [1]. This implments up to 5 retries of transaction commits for upsert and delete operations.

1: https://www.cockroachlabs.com/docs/stable/transaction-retry-error-reference.html