### PR TITLE
Add TTL feature to allow metdata/userdata to expire after a set period of time

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -27,6 +27,8 @@ import (
 const (
 	serviceName = "metadata-service"
 
+	cacheTTLDefault = time.Hour
+
 	dbMaxRetriesDefault       = 5
 	dbRetryMaxIntervalDefault = 3 * time.Second
 
@@ -112,6 +114,9 @@ func init() {
 
 	serveCmd.Flags().String("user-state-url", "", "An optional golang template string used to build a URL which instances can use for sending user state events. This template string will be evaluated against the instance metadata, and appended as a 'user_state_url' field on the metadata document served to instances. If no template string is specified, the 'user_state_url' field will not be added to the metadata document.")
 	viperBindFlag("metadata.user_state_url", serveCmd.Flags().Lookup("user-state-url"))
+
+	serveCmd.Flags().Duration("cache-ttl", cacheTTLDefault, "TTL, in seconds, to consider metadata and userdata valid for. Set to 0 to disable.")
+	viperBindFlag("cache_ttl", serveCmd.Flags().Lookup("cache-ttl"))
 
 	serveCmd.Flags().Duration("shutdown-grace-period", shutdownGracePeriod, "The grace period for requests to finish before forcibly exiting.")
 	viperBindFlag("shutdown_grace_period", serveCmd.Flags().Lookup("shutdown-grace-period"))

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,6 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
-github.com/cockroachdb/cockroach-go/v2 v2.3.3 h1:fNmtG6XhoA1DhdDCIu66YyGSsNb1szj4CaAsbDxRmy4=
-github.com/cockroachdb/cockroach-go/v2 v2.3.3/go.mod h1:1wNJ45eSXW9AnOc3skntW9ZUZz6gxrQK3cOj3rK+BC8=
 github.com/cockroachdb/cockroach-go/v2 v2.3.4 h1:dm6K7p7VOldWbgUllY4D/1Qtqv/D0UKm6OLhpF53aJU=
 github.com/cockroachdb/cockroach-go/v2 v2.3.4/go.mod h1:1wNJ45eSXW9AnOc3skntW9ZUZz6gxrQK3cOj3rK+BC8=
 github.com/coreos/go-oidc/v3 v3.6.0 h1:AKVxfYw1Gmkn/w96z0DbT/B/xFnzTd3MkZvWLjF4n/o=
@@ -198,8 +196,6 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.10.0/go.mod h1:74x4gJWsvQexRdW8Pn3dXSGrTK4nAUsbPlLADvpJkos=
-github.com/go-playground/validator/v10 v10.14.0 h1:vgvQWe3XCz3gIeFDm/HnTIbj6UGmg/+t63MyGU2n5js=
-github.com/go-playground/validator/v10 v10.14.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/go-playground/validator/v10 v10.14.1 h1:9c50NUPC30zyuKprjL3vNZ0m5oG+jU0zvx4AqHGnv4k=
 github.com/go-playground/validator/v10 v10.14.1/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=

--- a/internal/dbtools/fixtures.go
+++ b/internal/dbtools/fixtures.go
@@ -126,11 +126,7 @@ func addFixtures() error {
 		return err
 	}
 
-	if err := setupInstanceF(ctx, testDB); err != nil {
-		return err
-	}
-
-	return nil
+	return setupInstanceF(ctx, testDB)
 }
 
 func setupInstanceA(ctx context.Context, db *sqlx.DB) error {
@@ -294,11 +290,7 @@ func setupInstanceC(ctx context.Context, db *sqlx.DB) error {
 		return err
 	}
 
-	if err := FixtureInstanceC.InstanceUserdata.Insert(ctx, db, boil.Infer()); err != nil {
-		return err
-	}
-
-	return nil
+	return FixtureInstanceC.InstanceUserdata.Insert(ctx, db, boil.Infer())
 }
 
 func setupInstanceD(ctx context.Context, db *sqlx.DB) error {
@@ -310,11 +302,7 @@ func setupInstanceD(ctx context.Context, db *sqlx.DB) error {
 		},
 	}
 
-	if err := FixtureInstanceD.InstanceMetadata.Insert(ctx, db, boil.Infer()); err != nil {
-		return err
-	}
-
-	return nil
+	return FixtureInstanceD.InstanceMetadata.Insert(ctx, db, boil.Infer())
 }
 
 func setupInstanceE(ctx context.Context, db *sqlx.DB) error {
@@ -356,11 +344,7 @@ func setupInstanceF(ctx context.Context, db *sqlx.DB) error {
 		},
 	}
 
-	if err := FixtureInstanceF.InstanceUserdata.Insert(ctx, db, boil.Infer()); err != nil {
-		return err
-	}
-
-	return nil
+	return FixtureInstanceF.InstanceUserdata.Insert(ctx, db, boil.Infer())
 }
 
 func getIPs(addresses []string) []string {

--- a/pkg/api/v1/router_instance_metadata.go
+++ b/pkg/api/v1/router_instance_metadata.go
@@ -70,6 +70,15 @@ func (r *Router) instanceMetadataGet(c *gin.Context) {
 		return
 	}
 
+	// Treat metadata that's older then its TTL as non-existent
+	cacheTTL := viper.GetDuration("cache_ttl")
+	if metadata != nil && cacheTTL != 0 && metadata.UpdatedAt.Add(cacheTTL).Before(time.Now()) {
+		r.Logger.Sugar().Info("Metadata for ", metadata.ID, " is older than our TTL, ignoring")
+		notFoundResponse(c)
+
+		return
+	}
+
 	if metadata != nil {
 		augmentedMetadata, err := addTemplateFields(metadata.Metadata, r.TemplateFields)
 		if err != nil {
@@ -140,6 +149,15 @@ func (r *Router) instanceMetadataExistsInternal(c *gin.Context) {
 		return
 	}
 
+	// Treat metadata that's older then its TTL as non-existent
+	cacheTTL := viper.GetDuration("cache_ttl")
+	if metadata != nil && cacheTTL != 0 && metadata.UpdatedAt.Add(cacheTTL).Before(time.Now()) {
+		r.Logger.Sugar().Info("Metadata for ", metadata.ID, " is older than our TTL, ignoring (exists check)")
+		c.Status(http.StatusNotFound)
+
+		return
+	}
+
 	// HEAD request responses still set the Content-Length header to what it
 	// would be if we were returning the metadata
 	bytes, err := json.Marshal(metadata.Metadata)
@@ -162,6 +180,15 @@ func (r *Router) instanceUserdataGet(c *gin.Context) {
 	// error result to the caller.
 	if err != nil && !errors.Is(err, errNotFound) {
 		dbErrorResponse(r.Logger, c, err)
+		return
+	}
+
+	// Treat userdata that's older then its TTL as non-existent
+	cacheTTL := viper.GetDuration("cache_ttl")
+	if userdata != nil && cacheTTL != 0 && userdata.UpdatedAt.Add(cacheTTL).Before(time.Now()) {
+		r.Logger.Sugar().Info("Userdata for ", userdata.ID, " is older than our TTL, ignoring")
+		notFoundResponse(c)
+
 		return
 	}
 
@@ -216,6 +243,15 @@ func (r *Router) instanceUserdataExistsInternal(c *gin.Context) {
 
 	if err != nil {
 		c.Status(http.StatusNotFound)
+		return
+	}
+
+	// Treat userdata that's older then its TTL as non-existent
+	cacheTTL := viper.GetDuration("cache_ttl")
+	if userdata != nil && cacheTTL != 0 && userdata.UpdatedAt.Add(cacheTTL).Before(time.Now()) {
+		r.Logger.Sugar().Info("Userdata for ", userdata.ID, " is older than our TTL, ignoring (exists check)")
+		c.Status(http.StatusNotFound)
+
 		return
 	}
 

--- a/pkg/api/v1/router_instance_metadata_lookup_test.go
+++ b/pkg/api/v1/router_instance_metadata_lookup_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 
 	"go.hollow.sh/metadataservice/internal/lookup"
@@ -57,6 +59,42 @@ func TestGetMetadataLookupByIP(t *testing.T) {
 			},
 		},
 	}
+
+	for _, testcase := range testCases {
+		t.Run(testcase.testName, func(t *testing.T) {
+			lookupClient.setResponse(testcase.instanceIP, testcase.lookupResponse)
+			w := httptest.NewRecorder()
+
+			req, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, v1api.GetMetadataPath(), nil)
+			req.RemoteAddr = net.JoinHostPort(testcase.instanceIP, "")
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, testcase.expectedStatus, w.Code)
+		})
+	}
+
+	// Verify cache TTL settings are honored by setting the TTL to -1 second so we can avoid having to sleep
+	viper.Set("cache_ttl", -time.Second)
+
+	for _, testcase := range testCases {
+		t.Run(testcase.testName, func(t *testing.T) {
+			lookupClient.setResponse(testcase.instanceIP, testcase.lookupResponse)
+			w := httptest.NewRecorder()
+
+			req, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, v1api.GetMetadataPath(), nil)
+			req.RemoteAddr = net.JoinHostPort(testcase.instanceIP, "")
+			router.ServeHTTP(w, req)
+
+			if testcase.expectedStatus != http.StatusInternalServerError {
+				testcase.expectedStatus = http.StatusNotFound
+			}
+
+			assert.Equal(t, testcase.expectedStatus, w.Code)
+		})
+	}
+
+	// Setting cache_ttl to zero should disable the TTL behavior
+	viper.Set("cache_ttl", 0)
 
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {


### PR DESCRIPTION
The default is one hour, but can be configured via a cmdline flag or environment variable. Set this parameter to zero to disable it.