### PR TITLE
migrations: add a UNIQUE constraint on address for instance_ip_addresses

### DIFF
--- a/db/migrations/00005_add_unique_constraint_to_instance_ip_addresses_address.sql
+++ b/db/migrations/00005_add_unique_constraint_to_instance_ip_addresses_address.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- +goose StatementBegin
+
+ALTER TABLE instance_ip_addresses ADD CONSTRAINT unique_address UNIQUE (address);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP CONSTRAINT unique_address ON instance_ip_addresses;
+
+-- +goose StatementEnd


### PR DESCRIPTION
This will prevent duplicate IPs from being added to instance_ip_addresses, which has been happening due to race conditions during upserts.