### PR TITLE
Revert "Remove cosign step from CI"

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           go-version: '1.21'
       -
+        name: install cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.13.1'
+      -
         uses: anchore/sbom-action/download-syft@v0.15.8
       -
         name: Run GoReleaser


### PR DESCRIPTION
This reverts commit fa50477511af6bff5ecf5e0371ea6f53656730b2.

This didn't do what I thought it did - it is actually necessary in the building of project releases.