### PR TITLE
Update cosign-release and go version

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -29,12 +29,12 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       -
         name: install cosign
         uses: sigstore/cosign-installer@main
         with:
-          cosign-release: 'v1.13.1'
+          cosign-release: 'v1.13.6'
       -
         uses: anchore/sbom-action/download-syft@v0.15.8
       -


### PR DESCRIPTION
Hoping this fixes keyless signing issues in the GH action.