### PR TITLE
Refactor upserts to address race conditions

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -29,7 +29,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
       -
         name: install cosign
         uses: sigstore/cosign-installer@main

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.23'
 
       - name: Install cockroach binary
         run: curl https://binaries.cockroachdb.com/cockroach-v21.1.7.linux-amd64.tgz | tar -xz && sudo cp -i cockroach-v21.1.7.linux-amd64/cockroach /usr/local/bin/
@@ -33,7 +33,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.54.2
+          version: v1.60.3
           args: --timeout=5m
           skip-pkg-cache: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,15 +21,15 @@ linters:
 
     # additional linters
     - bodyclose
+    - err113
     - gocritic
     - gocyclo
-    - goerr113
     - gofmt
     # - gofumpt
     - goimports
-    - gomnd
     - govet
     - misspell
+    - mnd
     - noctx
     - revive
     - stylecheck

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.21 as builder
+FROM golang:1.23.4 as builder
 
 # Create and change to the app directory.
 WORKDIR /app
@@ -11,7 +11,7 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . ./
 
-RUN go mod tidy -go=1.21
+RUN go mod tidy -go=1.23
 
 # Build the binary.
 # -mod=readonly ensures immutable go.mod and go.sum in container builds.

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ clean: docker-clean
 
 vendor:
 	@go mod download
-	@go mod tidy -go=1.21
+	@go mod tidy -go=1.23
 
 docker-up:
 	@docker-compose -f quickstart.yml up -d crdb

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -38,7 +38,7 @@ const (
 var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "starts the metadata server",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		serve(cmd.Context())
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module go.hollow.sh/metadataservice
 
-go 1.22.7
+go 1.23
+
+toolchain go1.23.4
 
 require (
 	github.com/cockroachdb/cockroach-go/v2 v2.3.6

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.49.0
 	go.opentelemetry.io/otel v1.24.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/oauth2 v0.17.0
 )
 
@@ -57,7 +58,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	golang.org/x/arch v0.7.0 // indirect
-	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20231106174013-bbf56f31fb17 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -130,7 +130,6 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -596,8 +595,6 @@ github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155
 github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
 github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
-github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
-github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
@@ -610,8 +607,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -622,7 +620,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=

--- a/internal/dbtools/testtools.go
+++ b/internal/dbtools/testtools.go
@@ -54,6 +54,7 @@ func DatabaseTest(t *testing.T) *sqlx.DB {
 
 	t.Cleanup(func() {
 		cleanDB()
+
 		err := addFixtures()
 		require.NoError(t, err, "Unexpected error setting up fixture data")
 	})

--- a/internal/lookup/client_test.go
+++ b/internal/lookup/client_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func lookupMetadataServerMock(instance testInstance) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		resp := instance.MetadataResponse()
 
 		_ = json.NewEncoder(w).Encode(resp)
@@ -23,7 +23,7 @@ func lookupMetadataServerMock(instance testInstance) *httptest.Server {
 }
 
 func lookupUserdataServerMock(instance testInstance) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		resp := instance.UserdataResponse()
 
 		_ = json.NewEncoder(w).Encode(resp)
@@ -31,8 +31,9 @@ func lookupUserdataServerMock(instance testInstance) *httptest.Server {
 }
 
 func lookupServerWithStatusMock(status int, body string) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(status)
+
 		if len(body) > 0 {
 			fmt.Fprint(w, body)
 		}

--- a/internal/middleware/identify_instance_test.go
+++ b/internal/middleware/identify_instance_test.go
@@ -89,6 +89,7 @@ func TestIdentifyInstanceByIP(t *testing.T) {
 					assert.Equal(t, nil, instanceIDValue)
 					assert.False(t, found)
 				}
+
 				c.JSON(http.StatusOK, "ok")
 			})
 

--- a/pkg/api/v1/router.go
+++ b/pkg/api/v1/router.go
@@ -270,6 +270,7 @@ func setupValidator() {
 		if name == "-" {
 			return ""
 		}
+
 		return name
 	})
 }

--- a/pkg/api/v1/router_instance_ec2_metadata_lookup_test.go
+++ b/pkg/api/v1/router_instance_ec2_metadata_lookup_test.go
@@ -67,6 +67,7 @@ func TestGetEc2MetadataLookupByIP(t *testing.T) {
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {
 			lookupClient.setResponse(testcase.instanceIP, testcase.lookupResponse)
+
 			w := httptest.NewRecorder()
 
 			req, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, v1api.GetEc2MetadataPath(), nil)
@@ -126,6 +127,7 @@ func TestGetEc2MetadataItemLookupByIP(t *testing.T) {
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {
 			lookupClient.setResponse(testcase.instanceIP, testcase.lookupResponse)
+
 			w := httptest.NewRecorder()
 
 			req, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, v1api.GetEc2MetadataItemPath("hostname"), nil)

--- a/pkg/api/v1/router_instance_ec2_userdata_lookup_test.go
+++ b/pkg/api/v1/router_instance_ec2_userdata_lookup_test.go
@@ -67,6 +67,7 @@ func TestGetEc2UserdataLookupByIP(t *testing.T) {
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {
 			lookupClient.setResponse(testcase.instanceIP, testcase.lookupResponse)
+
 			w := httptest.NewRecorder()
 
 			req, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, v1api.GetEc2UserdataPath(), nil)

--- a/pkg/api/v1/router_instance_metadata_lookup_test.go
+++ b/pkg/api/v1/router_instance_metadata_lookup_test.go
@@ -67,6 +67,7 @@ func TestGetMetadataLookupByIP(t *testing.T) {
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {
 			lookupClient.setResponse(testcase.instanceIP, testcase.lookupResponse)
+
 			w := httptest.NewRecorder()
 
 			req, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, v1api.GetMetadataPath(), nil)

--- a/pkg/api/v1/router_instance_metadata_test.go
+++ b/pkg/api/v1/router_instance_metadata_test.go
@@ -295,6 +295,7 @@ func TestSetMetadataRequestValidations(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+
 			w := httptest.NewRecorder()
 
 			req, _ := http.NewRequestWithContext(context.TODO(), http.MethodPost, v1api.GetInternalMetadataPath(), bytes.NewReader(reqBody))

--- a/pkg/api/v1/router_instance_userdata_lookup_test.go
+++ b/pkg/api/v1/router_instance_userdata_lookup_test.go
@@ -61,6 +61,7 @@ func TestGetUserdataLookupByIP(t *testing.T) {
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {
 			lookupClient.setResponse(testcase.instanceIP, testcase.lookupResponse)
+
 			w := httptest.NewRecorder()
 
 			req, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, v1api.GetUserdataPath(), nil)

--- a/pkg/api/v1/router_instance_userdata_test.go
+++ b/pkg/api/v1/router_instance_userdata_test.go
@@ -184,6 +184,7 @@ func TestSetUserdataRequestValidations(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+
 			w := httptest.NewRecorder()
 
 			req, _ := http.NewRequestWithContext(context.TODO(), http.MethodPost, v1api.GetInternalUserdataPath(), bytes.NewReader(reqBody))

--- a/quickstart-auth.yml
+++ b/quickstart-auth.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   metadataservice:
     environment:

--- a/quickstart-dev.yml
+++ b/quickstart-dev.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   metadataservice:
     build:

--- a/quickstart-tracing.yml
+++ b/quickstart-tracing.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   metadataservice:
     depends_on:

--- a/quickstart.yml
+++ b/quickstart.yml
@@ -29,7 +29,7 @@ services:
       - metadataservice
 
   crdb:
-    image: cockroachdb/cockroach:latest-v23.1
+    image: cockroachdb/cockroach:latest-v23.2
     volumes:
       - db:/cockroach/cockroach-data
     command: start-single-node --insecure

--- a/quickstart.yml
+++ b/quickstart.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   metadataservice:
     image: ghcr.io/metal-toolbox/hollow-metadaaservice:v0.0.32

--- a/quickstart.yml
+++ b/quickstart.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   metadataservice:
-    image: ghcr.io/metal-toolbox/hollow-metadaaservice:v0.0.27
+    image: ghcr.io/metal-toolbox/hollow-metadaaservice:v0.0.32
     depends_on:
       crdb:
         condition: service_healthy
@@ -18,7 +18,7 @@ services:
       - metadataservice
 
   metadataservice-migrate:
-    image: ghcr.io/metal-toolbox/hollow-metadataservice:v0.0.27
+    image: ghcr.io/metal-toolbox/hollow-metadataservice:v0.0.32
     command:
       migrate up
     depends_on:


### PR DESCRIPTION
When two metadata updates arrive in close succession, it is possible for
the first one to overwrite the second one if the first transaction is
retried.
    
This refactors our doUpsert code to be more robust against race
conditions in two ways:
    
* We use SELECT FOR UPDATE to lock all ip address rows at the start of
  the transaction
* We use crdb.ExecuteTx(), which automatically handles retries due to
  transient errors (e.g, db serialization errors).
    
The outer retry logic (for loop) is only there as a catch-all for edge
cases that need to be better understood, because it too still allows for
race conditions if the transaction run by ExecuteTx() is failing for
transient reasons. We log this case thoroughly to allow for debugging.