### PR TITLE
Fixes for doUpsert context cancellations

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -29,7 +29,7 @@ const (
 
 	dbMaxRetriesDefault       = 5
 	dbRetryMaxIntervalDefault = 3 * time.Second
-	dbTxTimoutDefault         = 15 * time.Second
+	dbTxTimeoutDefault        = 25 * time.Second
 
 	shutdownGracePeriod = 10 * time.Second
 )
@@ -60,7 +60,7 @@ func init() {
 	serveCmd.Flags().Duration("db-retry-max-interval", dbRetryMaxIntervalDefault, "maximum number of seconds to sleep between db transaction retries (includes random jitter)")
 	viperBindFlag("crdb.retry_interval", serveCmd.Flags().Lookup("db-retry-max-interval"))
 
-	serveCmd.Flags().Duration("db-tx-timeout", dbTxTimoutDefault, "maximum number of seconds to allow db transactions to run for")
+	serveCmd.Flags().Duration("db-tx-timeout", dbTxTimeoutDefault, "maximum number of seconds to allow db transactions to run for")
 	viperBindFlag("crdb.tx_timeout", serveCmd.Flags().Lookup("db-tx-timeout"))
 
 	// OIDC Flags

--- a/internal/httpsrv/server.go
+++ b/internal/httpsrv/server.go
@@ -40,8 +40,8 @@ type Server struct {
 }
 
 var (
-	readTimeout     = 10 * time.Second
-	writeTimeout    = 20 * time.Second
+	readTimeout     = 20 * time.Second
+	writeTimeout    = 30 * time.Second
 	corsMaxAge      = 12 * time.Hour
 	dbPingTimeout   = 10 * time.Second
 	shutdownTimeout = 10 * time.Second


### PR DESCRIPTION
We've seen some cases of the doUpsert DB transaction hitting context timeouts, so bump up these values a bit to account for the complex operations done within a doUpsert transaction.

This also fixes a bug where a context was initially defined before a retry loop, and if the transaction was getting cancelled due to a context timeout, then all subsequent retries would immediately timeout as well. So generate a new context for each retry iteration.