### PR TITLE
Better handling of upserts involving many elastic IPs

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -27,7 +27,7 @@ import (
 const (
 	serviceName = "metadata-service"
 
-	dbMaxRetriesDefault       = 5
+	dbMaxRetriesDefault       = 3
 	dbRetryMaxIntervalDefault = 3 * time.Second
 	dbTxTimeoutDefault        = 25 * time.Second
 


### PR DESCRIPTION
In some outlier cases (e.g, adding 100+ IPs to an instance), the default db transaction timeout is insufficient. This dynamically increases the transaction timeout for large numbers of IP insertions, and includes additional logging of IP insertions.
