### PR TITLE
Update go.mod to specify 1.23.0 as the minimum version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.hollow.sh/metadataservice
 
-go 1.23
+go 1.23.0
 
 toolchain go1.23.6
 


### PR DESCRIPTION
This should un-block some renovate PRs that are failing lint/testing.