### PR TITLE
Specify go 1.23.0 when running go mod tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ clean: docker-clean
 
 vendor:
 	@go mod download
-	@go mod tidy -go=1.23
+	@go mod tidy -go=1.23.0
 
 docker-up:
 	@docker-compose -f quickstart.yml up -d crdb


### PR DESCRIPTION
This is what actually fixes the renovate complaints.